### PR TITLE
Introduce a method to retrieve documents similar to another

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "near-proximity",
  "obkv",
  "once_cell",
+ "ordered-float",
  "rayon",
  "ringtail",
  "roaring",
@@ -707,6 +708,15 @@ name = "oorandom"
 version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+
+[[package]]
+name = "ordered-float"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "page_size"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ memmap = "0.7.0"
 near-proximity = { git = "https://github.com/Kerollmops/plane-sweep-proximity", rev = "6608205" }
 obkv = "0.1.0"
 once_cell = "1.4.0"
+ordered-float = "2.0.0"
 rayon = "1.3.1"
 ringtail = "0.3.0"
 roaring = "0.6.1"

--- a/http-ui/Cargo.lock
+++ b/http-ui/Cargo.lock
@@ -812,7 +812,6 @@ checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -981,7 +980,6 @@ dependencies = [
  "grenad",
  "heed",
  "human_format",
- "indexmap",
  "itertools",
  "jemallocator",
  "levenshtein_automata",

--- a/http-ui/Cargo.lock
+++ b/http-ui/Cargo.lock
@@ -989,6 +989,7 @@ dependencies = [
  "near-proximity",
  "obkv",
  "once_cell",
+ "ordered-float",
  "rayon",
  "ringtail",
  "roaring",
@@ -1204,6 +1205,15 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "ordered-float"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "page_size"


### PR DESCRIPTION
## Return similar documents based on the least common words

This little feature returns the similar documents related to the given one, it find all the words and frequencies of them in the given document then find a maximum number of documents (up to the given limit) which also got these words.

Here is an example with this input document, the 2Pac, Only God Can Judge Me song.

```json
{
    "title": "Only God Can Judge Me",
    "artist": "2Pac",
    "album": "All Eyez On Me",
    "id": "105860510"
}
```

```json
[
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "152334210",
        "title": "Only God Can Judge Me"
    },
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "22643009",
        "title": "Only God Can Judge Me"
    },
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "23836910",
        "title": "Only God Can Judge Me"
    },
    ...
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "105860500",
        "title": "Book 1"
    },
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "105860501",
        "title": "Ambitionz Az A Ridah"
    },
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "105860502",
        "title": "All About U"
    },
    {
        "album": "All Eyez On Me",
        "artist": "2Pac",
        "id": "105860503",
        "title": "Skandalouz"
    },
    ...
]
```

## Doesn't fall into some edge-cases

It also support the edge cases where the given document's least common word does only appear in this document and therefore this method would not be able to find any other similar document. This method first try to find a maximum number of document with the least common words and, then, reduce the documents by the other, a little bit more common, words.

### Example

Here is a little example of a query request that would give no result if this previous solution wasn't applied. With this first document the algorithm will now answer with some documents and don't focus on this only least common (and unique in the dataset) word "Kuartukombys".

```json
{
    "title": "Kuartukombys Tasobreahan Syedade",
    "artist": "Platform (6)",
    "album": "Templates",
    "id": "130946805"
}
```

```json
[
    {
        "album": "Templates",
        "artist": "Platform (6)",
        "id": "130946800",
        "title": "Uótemsomdó E Somdú"
    },
    {
        "album": "Templates",
        "artist": "Platform (6)",
        "id": "130946801",
        "title": "Absolutement Abdominable"
    },
    {
        "album": "Templates",
        "artist": "Platform (6)",
        "id": "130946802",
        "title": "Haphapénaway"
    },
    ...
]
```