### PR TITLE
Compress updates content using gzip

### DIFF
--- a/http-ui/Cargo.lock
+++ b/http-ui/Cargo.lock
@@ -81,6 +81,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1ff21a63d3262af46b9f33a826a8d134e2d0d9b2179c86034948b732ea8b2a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +758,7 @@ dependencies = [
  "anyhow",
  "askama",
  "askama_warp",
+ "async-compression",
  "bytes",
  "flate2",
  "futures",

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.28"
+async-compression = { version = "0.3.6", features = ["gzip", "tokio-02"] }
 grenad = { git = "https://github.com/Kerollmops/grenad.git", rev = "3adcb26" }
 heed = "0.10.5"
 memmap = "0.7.0"


### PR DESCRIPTION
Compressing updates allows us to send big updates and index them in one batch, which is 1. faster and 2. less disk consuming.

By faster I mean: the whole dataset will be available faster than if we had indexed it in more batches. And by less disk consuming I take for example a 37m lines ndJSON that is 1.7GB compressed but 6.4GB uncompressed, also there are big performance tricks on the addition of the first documents in the index (LMDB append).