### PR TITLE
Use the byte-unit crate to ease library usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8758c32833faaae35b24a73d332e62d0528e89076ae841c63940e37008b153"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +678,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "byte-unit",
  "byteorder",
  "criterion",
  "crossbeam-channel",
@@ -1439,6 +1449,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.28"
 bstr = "0.2.13"
+byte-unit = { version = "4.0.9", default-features = false, features = ["std"] }
 byteorder = "1.3.4"
 crossbeam-channel = "0.5.0"
 csv = "1.1.3"

--- a/http-ui/Cargo.lock
+++ b/http-ui/Cargo.lock
@@ -197,6 +197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8758c32833faaae35b24a73d332e62d0528e89076ae841c63940e37008b153"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +768,7 @@ dependencies = [
  "askama",
  "askama_warp",
  "async-compression",
+ "byte-unit",
  "bytes",
  "flate2",
  "futures",
@@ -1010,6 +1020,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "byte-unit",
  "byteorder",
  "crossbeam-channel",
  "csv",
@@ -2211,6 +2222,12 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
 
 [[package]]
 name = "uuid"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.28"
 async-compression = { version = "0.3.6", features = ["gzip", "tokio-02"] }
+byte-unit = { version = "4.0.9", default-features = false, features = ["std"] }
 grenad = { git = "https://github.com/Kerollmops/grenad.git", rev = "3adcb26" }
 heed = "0.10.5"
 memmap = "0.7.0"

--- a/src/subcommand/infos.rs
+++ b/src/subcommand/infos.rs
@@ -2,9 +2,10 @@ use std::path::PathBuf;
 use std::{str, io, fmt};
 
 use anyhow::Context;
+use byte_unit::Byte;
+use crate::Index;
 use heed::EnvOpenOptions;
 use structopt::StructOpt;
-use crate::Index;
 
 use Command::*;
 
@@ -39,8 +40,8 @@ pub struct Opt {
 
     /// The maximum size the database can take on disk. It is recommended to specify
     /// the whole disk space (value must be a multiple of a page size).
-    #[structopt(long = "db-size", default_value = "107374182400")] // 100 GB
-    database_size: usize,
+    #[structopt(long = "db-size", default_value = "100 GiB")]
+    database_size: Byte,
 
     /// Verbose mode (-v, -vv, -vvv, etc.)
     #[structopt(short, long, parse(from_occurrences))]
@@ -159,7 +160,7 @@ pub fn run(opt: Opt) -> anyhow::Result<()> {
         .init()?;
 
     let mut options = EnvOpenOptions::new();
-    options.map_size(opt.database_size);
+    options.map_size(opt.database_size.get_bytes() as usize);
 
     // Open the LMDB database.
     let index = Index::new(options, opt.database)?;

--- a/src/subcommand/search.rs
+++ b/src/subcommand/search.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::Context;
+use byte_unit::Byte;
 use heed::EnvOpenOptions;
 use log::debug;
 use structopt::StructOpt;
@@ -21,8 +22,8 @@ pub struct Opt {
 
     /// The maximum size the database can take on disk. It is recommended to specify
     /// the whole disk space (value must be a multiple of a page size).
-    #[structopt(long = "db-size", default_value = "107374182400")] // 100 GB
-    database_size: usize,
+    #[structopt(long = "db-size", default_value = "100 GiB")]
+    database_size: Byte,
 
     /// Verbose mode (-v, -vv, -vvv, etc.)
     #[structopt(short, long, parse(from_occurrences))]
@@ -41,7 +42,7 @@ pub fn run(opt: Opt) -> anyhow::Result<()> {
 
     std::fs::create_dir_all(&opt.database)?;
     let mut options = EnvOpenOptions::new();
-    options.map_size(opt.database_size);
+    options.map_size(opt.database_size.get_bytes() as usize);
 
     // Open the LMDB database.
     let index = Index::new(options, &opt.database)?;


### PR DESCRIPTION
The [byte-unit crate](https://lib.rs/byte-unit) can parse and understand byte expressions and byte units (e.g. 123 GiB, 12MB).