### PR TITLE
create update handler trait

### DIFF
--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -306,7 +306,8 @@ async fn main() -> anyhow::Result<()> {
     let update_store = UpdateStore::open(
         update_store_options,
         update_store_path,
-        move |update_id, meta, content| {
+        // the type hint is necessary: https://github.com/rust-lang/rust/issues/32600
+        move |update_id, meta, content:&_| {
             // We prepare the update by using the update builder.
             let mut update_builder = UpdateBuilder::new();
             if let Some(max_nb_chunks) = indexer_opt_cloned.max_nb_chunks {

--- a/src/search/facet/facet_condition.rs
+++ b/src/search/facet/facet_condition.rs
@@ -61,6 +61,7 @@ impl FacetStringOperator {
         FacetStringOperator::Equal(s.to_lowercase())
     }
 
+    #[allow(dead_code)]
     fn not_equal(s: &str) -> Self {
         FacetStringOperator::equal(s).negate()
     }


### PR DESCRIPTION
Replace update function with trait object to pass state in a cleaner manner, and implement this trait on `FnMut` to be non-breaking