### PR TITLE
implement display for criterion

### DIFF
--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -76,8 +76,8 @@ impl fmt::Display for Criterion {
             Attribute       => f.write_str("attribute"),
             WordsPosition   => f.write_str("wordsPosition"),
             Exactness       => f.write_str("exactness"),
-            Asc(attr)       => write!(f, "asc({:?})", attr),
-            Desc(attr)      => write!(f, "desc({:?})", attr),
+            Asc(attr)       => write!(f, "asc({})", attr),
+            Desc(attr)      => write!(f, "desc({})", attr),
         }
     }
 }

--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 
 use anyhow::{Context, bail};
 use regex::Regex;
@@ -62,4 +63,21 @@ pub fn default_criteria() -> Vec<Criterion> {
         Criterion::WordsPosition,
         Criterion::Exactness,
     ]
+}
+
+impl fmt::Display for Criterion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Criterion::*;
+
+        match self {
+            Typo            => f.write_str("typo"),
+            Words           => f.write_str("words"),
+            Proximity       => f.write_str("proximity"),
+            Attribute       => f.write_str("attribute"),
+            WordsPosition   => f.write_str("wordsPosition"),
+            Exactness       => f.write_str("exactness"),
+            Asc(attr)       => write!(f, "asc({:?})", attr),
+            Desc(attr)      => write!(f, "desc({:?})", attr),
+        }
+    }
 }


### PR DESCRIPTION
Implement `Display` for `Criterion`.

Needed to return the criterion with the correct formating to the user.
