### PR TITLE
Fix the searchable settings test

### DIFF
--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -283,7 +283,7 @@ mod tests {
 
         // First we send 3 documents with ids from 1 to 3.
         let mut wtxn = index.write_txn().unwrap();
-        let content = &b"name,age\nkevin,23\nkevina,21\nbenoit,34\n"[..];
+        let content = &b"id,name,age\n0,kevin,23\n1,kevina,21\n2,benoit,34\n"[..];
         let mut builder = IndexDocuments::new(&mut wtxn, &index, 0);
         builder.update_format(UpdateFormat::Csv);
         builder.execute(content, |_, _| ()).unwrap();


### PR DESCRIPTION
It fixes the CI of #101.

This PR fixes a spurious test of the settings updates that were sometimes failing because it searched in all the documents' attributes and was expected to find one document on the three provided but was sometimes finding two or three of those. It was because ids were autogenerated (UUID-v4), and those documents ids were containing the searched string of the test. This PR fixes this test by providing the ids directly.