### PR TITLE
Plane-Sweep proximity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,8 +53,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2925c4c290382f9d2fa3d1c1b6a63fa1427099721ecca4749b154cc9c25522"
 dependencies = [
  "askama_shared",
- "proc-macro2",
- "syn",
+ "proc-macro2 1.0.24",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -74,10 +74,10 @@ dependencies = [
  "nom",
  "num-traits",
  "percent-encoding",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
  "serde",
- "syn",
+ "syn 1.0.60",
  "toml",
 ]
 
@@ -622,9 +622,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1185,6 +1185,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "logging_timer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d0c249955c17c2f8f86b5f501b16d2509ebbe775f7b1d1d2b1ba85ade2a793"
+dependencies = [
+ "log",
+ "logging_timer_proc_macros",
+]
+
+[[package]]
+name = "logging_timer_proc_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482c2c28e6bcfe7c4274f82f701774d755e6aa873edfd619460fcd0966e0eb07"
+dependencies = [
+ "log",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "loom"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1291,7 @@ dependencies = [
  "levenshtein_automata",
  "linked-hash-map",
  "log",
+ "logging_timer",
  "maplit",
  "meilisearch-tokenizer",
  "memmap",
@@ -1554,9 +1577,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1632,9 +1655,9 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1643,9 +1666,9 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1713,9 +1736,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
  "version_check",
 ]
 
@@ -1725,8 +1748,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
  "version_check",
 ]
 
@@ -1744,11 +1767,20 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1759,11 +1791,20 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -2047,9 +2088,9 @@ version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2199,9 +2240,20 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -2210,9 +2262,9 @@ version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -2230,10 +2282,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -2359,9 +2411,9 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -2524,6 +2576,12 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
@@ -2653,9 +2711,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -2665,7 +2723,7 @@ version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
- "quote",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2675,9 +2733,9 @@ version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2782,8 +2840,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
- "proc-macro2",
- "syn",
+ "proc-macro2 1.0.24",
+ "syn 1.0.60",
  "synstructure",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "smallstr",
  "smallvec",
  "tempfile",
+ "tinytemplate",
  "uuid",
 ]
 
@@ -2305,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
+checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
 dependencies = [
  "serde",
  "serde_json",

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -46,6 +46,10 @@ itertools = "0.10.0"
 # logging
 log = "0.4.14"
 
+# We temporarily depend on this crate just to fix this issue
+# https://github.com/bheisler/TinyTemplate/pull/17
+tinytemplate = "=1.1.0"
+
 [dev-dependencies]
 criterion = "0.3.4"
 maplit = "1.0.2"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -45,6 +45,7 @@ itertools = "0.10.0"
 
 # logging
 log = "0.4.14"
+logging_timer = "1.0.0"
 
 # We temporarily depend on this crate just to fix this issue
 # https://github.com/bheisler/TinyTemplate/pull/17

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -15,6 +15,7 @@ use crate::heed_codec::facet::{FieldDocIdFacetI64Codec, FieldDocIdFacetF64Codec}
 use crate::search::criteria::{resolve_query_tree, CriteriaBuilder};
 use crate::search::facet::FacetIter;
 use crate::search::query_tree::Operation;
+use crate::search::WordDerivationsCache;
 use crate::{FieldsIdsMap, FieldId, Index};
 use super::{Criterion, CriterionResult};
 
@@ -92,7 +93,7 @@ impl<'t> AscDesc<'t> {
         let candidates = match &query_tree {
             Some(qt) => {
                 let context = CriteriaBuilder::new(rtxn, index)?;
-                let mut qt_candidates = resolve_query_tree(&context, qt, &mut HashMap::new())?;
+                let mut qt_candidates = resolve_query_tree(&context, qt, &mut HashMap::new(), &mut WordDerivationsCache::new())?;
                 if let Some(candidates) = candidates {
                     qt_candidates.intersect_with(&candidates);
                 }
@@ -145,7 +146,7 @@ impl<'t> AscDesc<'t> {
 }
 
 impl<'t> Criterion for AscDesc<'t> {
-    fn next(&mut self) -> anyhow::Result<Option<CriterionResult>> {
+    fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         loop {
             debug!("Facet {}({}) iteration",
                 if self.ascending { "Asc" } else { "Desc" }, self.field_name
@@ -157,7 +158,7 @@ impl<'t> Criterion for AscDesc<'t> {
                     let bucket_candidates = take(&mut self.bucket_candidates);
                     match self.parent.as_mut() {
                         Some(parent) => {
-                            match parent.next()? {
+                            match parent.next(wdcache)? {
                                 Some(CriterionResult { query_tree, mut candidates, bucket_candidates }) => {
                                     self.query_tree = query_tree;
                                     candidates.intersect_with(&self.faceted_candidates);

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -146,6 +146,7 @@ impl<'t> AscDesc<'t> {
 }
 
 impl<'t> Criterion for AscDesc<'t> {
+    #[logging_timer::time("AscDesc::{}")]
     fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         loop {
             debug!("Facet {}({}) iteration",

--- a/milli/src/search/criteria/fetcher.rs
+++ b/milli/src/search/criteria/fetcher.rs
@@ -48,6 +48,7 @@ impl<'t> Fetcher<'t> {
 }
 
 impl<'t> Criterion for Fetcher<'t> {
+    #[logging_timer::time("Fetcher::{}")]
     fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         use Candidates::{Allowed, Forbidden};
         loop {

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 use anyhow::bail;
 use roaring::RoaringBitmap;
 
-use crate::search::word_derivations;
-use crate::{DocumentId, Index};
+use crate::search::{word_derivations, WordDerivationsCache};
+use crate::{Index, DocumentId};
 
 use super::query_tree::{Operation, Query, QueryKind};
 use self::typo::Typo;
@@ -21,7 +21,7 @@ pub mod proximity;
 pub mod fetcher;
 
 pub trait Criterion {
-    fn next(&mut self) -> anyhow::Result<Option<CriterionResult>>;
+    fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>>;
 }
 
 /// The result of a call to the parent criterion.
@@ -164,12 +164,14 @@ pub fn resolve_query_tree<'t>(
     ctx: &'t dyn Context,
     query_tree: &Operation,
     cache: &mut HashMap<(Operation, u8), RoaringBitmap>,
+    wdcache: &mut WordDerivationsCache,
 ) -> anyhow::Result<RoaringBitmap>
 {
     fn resolve_operation<'t>(
         ctx: &'t dyn Context,
         query_tree: &Operation,
         cache: &mut HashMap<(Operation, u8), RoaringBitmap>,
+        wdcache: &mut WordDerivationsCache,
     ) -> anyhow::Result<RoaringBitmap>
     {
         use Operation::{And, Consecutive, Or, Query};
@@ -177,7 +179,7 @@ pub fn resolve_query_tree<'t>(
         match query_tree {
             And(ops) => {
                 let mut ops = ops.iter().map(|op| {
-                    resolve_operation(ctx, op, cache)
+                    resolve_operation(ctx, op, cache, wdcache)
                 }).collect::<anyhow::Result<Vec<_>>>()?;
 
                 ops.sort_unstable_by_key(|cds| cds.len());
@@ -200,7 +202,7 @@ pub fn resolve_query_tree<'t>(
                 for slice in ops.windows(2) {
                     match (&slice[0], &slice[1]) {
                         (Operation::Query(left), Operation::Query(right)) => {
-                            match query_pair_proximity_docids(ctx, left, right, 1)? {
+                            match query_pair_proximity_docids(ctx, left, right, 1, wdcache)? {
                                 pair_docids if pair_docids.is_empty() => {
                                     return Ok(RoaringBitmap::new())
                                 },
@@ -221,16 +223,16 @@ pub fn resolve_query_tree<'t>(
             Or(_, ops) => {
                 let mut candidates = RoaringBitmap::new();
                 for op in ops {
-                    let docids = resolve_operation(ctx, op, cache)?;
+                    let docids = resolve_operation(ctx, op, cache, wdcache)?;
                     candidates.union_with(&docids);
                 }
                 Ok(candidates)
             },
-            Query(q) => Ok(query_docids(ctx, q)?),
+            Query(q) => Ok(query_docids(ctx, q, wdcache)?),
         }
     }
 
-    resolve_operation(ctx, query_tree, cache)
+    resolve_operation(ctx, query_tree, cache, wdcache)
 }
 
 
@@ -239,7 +241,8 @@ fn all_word_pair_proximity_docids<T: AsRef<str>, U: AsRef<str>>(
     left_words: &[(T, u8)],
     right_words: &[(U, u8)],
     proximity: u8
-) -> anyhow::Result<RoaringBitmap> {
+) -> anyhow::Result<RoaringBitmap>
+{
     let mut docids = RoaringBitmap::new();
     for (left, _l_typo) in left_words {
         for (right, _r_typo) in right_words {
@@ -250,13 +253,18 @@ fn all_word_pair_proximity_docids<T: AsRef<str>, U: AsRef<str>>(
     Ok(docids)
 }
 
-fn query_docids(ctx: &dyn Context, query: &Query) -> anyhow::Result<RoaringBitmap> {
+fn query_docids(
+    ctx: &dyn Context,
+    query: &Query,
+    wdcache: &mut WordDerivationsCache,
+) -> anyhow::Result<RoaringBitmap>
+{
     match &query.kind {
         QueryKind::Exact { word, .. } => {
             if query.prefix && ctx.in_prefix_cache(&word) {
                 Ok(ctx.word_prefix_docids(&word)?.unwrap_or_default())
             } else if query.prefix {
-                let words = word_derivations(&word, true, 0, ctx.words_fst())?;
+                let words = word_derivations(&word, true, 0, ctx.words_fst(), wdcache)?;
                 let mut docids = RoaringBitmap::new();
                 for (word, _typo) in words {
                     let current_docids = ctx.word_docids(&word)?.unwrap_or_default();
@@ -268,7 +276,7 @@ fn query_docids(ctx: &dyn Context, query: &Query) -> anyhow::Result<RoaringBitma
             }
         },
         QueryKind::Tolerant { typo, word } => {
-            let words = word_derivations(&word, query.prefix, *typo, ctx.words_fst())?;
+            let words = word_derivations(&word, query.prefix, *typo, ctx.words_fst(), wdcache)?;
             let mut docids = RoaringBitmap::new();
             for (word, _typo) in words {
                 let current_docids = ctx.word_docids(&word)?.unwrap_or_default();
@@ -279,10 +287,17 @@ fn query_docids(ctx: &dyn Context, query: &Query) -> anyhow::Result<RoaringBitma
     }
 }
 
-fn query_pair_proximity_docids(ctx: &dyn Context, left: &Query, right: &Query, proximity: u8) -> anyhow::Result<RoaringBitmap> {
+fn query_pair_proximity_docids(
+    ctx: &dyn Context,
+    left: &Query,
+    right: &Query,
+    proximity: u8,
+    wdcache: &mut WordDerivationsCache,
+) -> anyhow::Result<RoaringBitmap>
+{
     if proximity >= 8 {
-        let mut candidates = query_docids(ctx, left)?;
-        let right_candidates = query_docids(ctx, right)?;
+        let mut candidates = query_docids(ctx, left, wdcache)?;
+        let right_candidates = query_docids(ctx, right, wdcache)?;
         candidates.intersect_with(&right_candidates);
         return Ok(candidates);
     }
@@ -293,14 +308,14 @@ fn query_pair_proximity_docids(ctx: &dyn Context, left: &Query, right: &Query, p
             if prefix && ctx.in_prefix_cache(&right) {
                 Ok(ctx.word_prefix_pair_proximity_docids(left.as_str(), right.as_str(), proximity)?.unwrap_or_default())
             } else if prefix {
-                let r_words = word_derivations(&right, true, 0, ctx.words_fst())?;
+                let r_words = word_derivations(&right, true, 0, ctx.words_fst(), wdcache)?;
                 all_word_pair_proximity_docids(ctx, &[(left, 0)], &r_words, proximity)
             } else {
                 Ok(ctx.word_pair_proximity_docids(left.as_str(), right.as_str(), proximity)?.unwrap_or_default())
             }
         },
         (QueryKind::Tolerant { typo, word: left }, QueryKind::Exact { word: right, .. }) => {
-            let l_words = word_derivations(&left, false, *typo, ctx.words_fst())?;
+            let l_words = word_derivations(&left, false, *typo, ctx.words_fst(), wdcache)?.to_owned();
             if prefix && ctx.in_prefix_cache(&right) {
                 let mut docids = RoaringBitmap::new();
                 for (left, _) in l_words {
@@ -309,19 +324,19 @@ fn query_pair_proximity_docids(ctx: &dyn Context, left: &Query, right: &Query, p
                 }
                 Ok(docids)
             } else if prefix {
-                let r_words = word_derivations(&right, true, 0, ctx.words_fst())?;
+                let r_words = word_derivations(&right, true, 0, ctx.words_fst(), wdcache)?;
                 all_word_pair_proximity_docids(ctx, &l_words, &r_words, proximity)
             } else {
                 all_word_pair_proximity_docids(ctx, &l_words, &[(right, 0)], proximity)
             }
         },
         (QueryKind::Exact { word: left, .. }, QueryKind::Tolerant { typo, word: right }) => {
-            let r_words = word_derivations(&right, prefix, *typo, ctx.words_fst())?;
+            let r_words = word_derivations(&right, prefix, *typo, ctx.words_fst(), wdcache)?;
             all_word_pair_proximity_docids(ctx, &[(left, 0)], &r_words, proximity)
         },
         (QueryKind::Tolerant { typo: l_typo, word: left }, QueryKind::Tolerant { typo: r_typo, word: right }) => {
-            let l_words = word_derivations(&left, false, *l_typo, ctx.words_fst())?;
-            let r_words = word_derivations(&right, prefix, *r_typo, ctx.words_fst())?;
+            let l_words = word_derivations(&left, false, *l_typo, ctx.words_fst(), wdcache)?.to_owned();
+            let r_words = word_derivations(&right, prefix, *r_typo, ctx.words_fst(), wdcache)?;
             all_word_pair_proximity_docids(ctx, &l_words, &r_words, proximity)
         },
     }

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -56,6 +56,7 @@ impl<'t> Proximity<'t> {
 }
 
 impl<'t> Criterion for Proximity<'t> {
+    #[logging_timer::time("Proximity::{}")]
     fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         use Candidates::{Allowed, Forbidden};
         loop {

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -357,9 +357,9 @@ fn resolve_plane_sweep_candidates(
         ) -> Option<(Position, u8, Position)>
         {
             // take the inner proximity of the first group as initial
-            let mut proximity = groups.first()?.1.1;
-            let left_most_pos = groups.first()?.1.0;
-            let right_most_pos = groups.last()?.1.2;
+            let (_, (_, mut proximity, _)) = groups.first()?;
+            let (_, (left_most_pos, _, _)) = groups.first()?;
+            let (_, (_, _, right_most_pos)) = groups.last()?;
 
             for pair in groups.windows(2) {
                 if let [(i1, (_, _, rpos1)), (i2, (lpos2, prox2, _))] = pair {
@@ -379,7 +379,7 @@ fn resolve_plane_sweep_candidates(
 
             // if groups should be consecutives, we will only accept groups with a proximity of 0
             if !consecutive || proximity == 0 {
-                Some((left_most_pos, proximity, right_most_pos))
+                Some((*left_most_pos, proximity, *right_most_pos))
             } else {
                 None
             }

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -379,7 +379,7 @@ mod test {
 
         let facet_candidates = None;
 
-let mut wdcache = WordDerivationsCache::new();
+        let mut wdcache = WordDerivationsCache::new();
         let mut criteria = Typo::initial(&context, Some(query_tree), facet_candidates);
 
         let candidates_1 = context.word_docids("split").unwrap().unwrap()
@@ -428,7 +428,7 @@ let mut wdcache = WordDerivationsCache::new();
         let query_tree = None;
         let facet_candidates = context.word_docids("earth").unwrap().unwrap();
 
-let mut wdcache = WordDerivationsCache::new();
+        let mut wdcache = WordDerivationsCache::new();
         let mut criteria = Typo::initial(&context, query_tree, Some(facet_candidates.clone()));
 
         let expected = CriterionResult {
@@ -457,7 +457,7 @@ let mut wdcache = WordDerivationsCache::new();
 
         let facet_candidates = context.word_docids("earth").unwrap().unwrap();
 
-let mut wdcache = WordDerivationsCache::new();
+        let mut wdcache = WordDerivationsCache::new();
         let mut criteria = Typo::initial(&context, Some(query_tree), Some(facet_candidates.clone()));
 
         let candidates_1 = context.word_docids("split").unwrap().unwrap()

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -53,6 +53,7 @@ impl<'t> Typo<'t> {
 }
 
 impl<'t> Criterion for Typo<'t> {
+    #[logging_timer::time("Typo::{}")]
     fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         use Candidates::{Allowed, Forbidden};
         loop {

--- a/milli/src/search/criteria/words.rs
+++ b/milli/src/search/criteria/words.rs
@@ -47,6 +47,7 @@ impl<'t> Words<'t> {
 }
 
 impl<'t> Criterion for Words<'t> {
+    #[logging_timer::time("Words::{}")]
     fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         use Candidates::{Allowed, Forbidden};
         loop {

--- a/milli/src/search/criteria/words.rs
+++ b/milli/src/search/criteria/words.rs
@@ -5,6 +5,7 @@ use log::debug;
 use roaring::RoaringBitmap;
 
 use crate::search::query_tree::Operation;
+use crate::search::WordDerivationsCache;
 use super::{resolve_query_tree, Candidates, Criterion, CriterionResult, Context};
 
 pub struct Words<'t> {
@@ -46,7 +47,7 @@ impl<'t> Words<'t> {
 }
 
 impl<'t> Criterion for Words<'t> {
-    fn next(&mut self) -> anyhow::Result<Option<CriterionResult>> {
+    fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
         use Candidates::{Allowed, Forbidden};
         loop {
             debug!("Words at iteration {} ({:?})", self.query_trees.len(), self.candidates);
@@ -61,7 +62,7 @@ impl<'t> Criterion for Words<'t> {
                     }));
                 },
                 (Some(qt), Allowed(candidates)) => {
-                    let mut found_candidates = resolve_query_tree(self.ctx, &qt, &mut self.candidates_cache)?;
+                    let mut found_candidates = resolve_query_tree(self.ctx, &qt, &mut self.candidates_cache, wdcache)?;
                     found_candidates.intersect_with(&candidates);
                     candidates.difference_with(&found_candidates);
 
@@ -77,7 +78,7 @@ impl<'t> Criterion for Words<'t> {
                     }));
                 },
                 (Some(qt), Forbidden(candidates)) => {
-                    let mut found_candidates = resolve_query_tree(self.ctx, &qt, &mut self.candidates_cache)?;
+                    let mut found_candidates = resolve_query_tree(self.ctx, &qt, &mut self.candidates_cache, wdcache)?;
                     found_candidates.difference_with(&candidates);
                     candidates.union_with(&found_candidates);
 
@@ -103,7 +104,7 @@ impl<'t> Criterion for Words<'t> {
                 (None, Forbidden(_)) => {
                     match self.parent.as_mut() {
                         Some(parent) => {
-                            match parent.next()? {
+                            match parent.next(wdcache)? {
                                 Some(CriterionResult { query_tree, candidates, bucket_candidates }) => {
                                     self.query_trees = query_tree.map(explode_query_tree).unwrap_or_default();
                                     self.candidates = Candidates::Allowed(candidates);


### PR DESCRIPTION
This PR introduces an alternative way to sort documents based on the proximity between the query words. It uses an iterative algorithm that fetches the word positions in all the candidate documents and does a simple sort on them by using [a plane sweep algorithm](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.26.3610&rep=rep1&type=pdf).