### PR TITLE
Optimize the words criterion

### DIFF
--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -160,9 +160,21 @@ impl<'t> Criterion for AscDesc<'t> {
                     match self.parent.as_mut() {
                         Some(parent) => {
                             match parent.next(wdcache)? {
-                                Some(CriterionResult { query_tree, mut candidates, bucket_candidates }) => {
+                                Some(CriterionResult { query_tree, candidates, bucket_candidates }) => {
                                     self.query_tree = query_tree;
-                                    candidates.intersect_with(&self.faceted_candidates);
+                                    let candidates = match (&self.query_tree, candidates) {
+                                        (_, Some(mut candidates)) => {
+                                            candidates.intersect_with(&self.faceted_candidates);
+                                            candidates
+                                        },
+                                        (Some(qt), None) => {
+                                            let context = CriteriaBuilder::new(&self.rtxn, &self.index)?;
+                                            let mut candidates = resolve_query_tree(&context, qt, &mut HashMap::new(), wdcache)?;
+                                            candidates.intersect_with(&self.faceted_candidates);
+                                            candidates
+                                        },
+                                        (None, None) => take(&mut self.faceted_candidates),
+                                    };
                                     self.candidates = facet_ordered(
                                         self.index,
                                         self.rtxn,
@@ -183,7 +195,7 @@ impl<'t> Criterion for AscDesc<'t> {
 
                     return Ok(Some(CriterionResult {
                         query_tree,
-                        candidates: RoaringBitmap::new(),
+                        candidates: Some(RoaringBitmap::new()),
                         bucket_candidates,
                     }));
                 },
@@ -195,7 +207,7 @@ impl<'t> Criterion for AscDesc<'t> {
 
                     return Ok(Some(CriterionResult {
                         query_tree: self.query_tree.clone(),
-                        candidates,
+                        candidates: Some(candidates),
                         bucket_candidates,
                     }));
                 },

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -175,6 +175,11 @@ impl<'t> Criterion for AscDesc<'t> {
                                         },
                                         (None, None) => take(&mut self.faceted_candidates),
                                     };
+                                    if bucket_candidates.is_empty() {
+                                        self.bucket_candidates.union_with(&candidates);
+                                    } else {
+                                        self.bucket_candidates.union_with(&bucket_candidates);
+                                    }
                                     self.candidates = facet_ordered(
                                         self.index,
                                         self.rtxn,
@@ -183,7 +188,6 @@ impl<'t> Criterion for AscDesc<'t> {
                                         self.ascending,
                                         candidates,
                                     )?;
-                                    self.bucket_candidates = bucket_candidates;
                                 },
                                 None => return Ok(None),
                             }

--- a/milli/src/search/criteria/fetcher.rs
+++ b/milli/src/search/criteria/fetcher.rs
@@ -8,12 +8,24 @@ use crate::search::query_tree::Operation;
 use crate::search::WordDerivationsCache;
 use super::{resolve_query_tree, Candidates, Criterion, CriterionResult, Context};
 
+/// The result of a call to the parent criterion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FetcherResult {
+    /// The query tree that must be used by the children criterion to fetch candidates.
+    pub query_tree: Option<Operation>,
+    /// The candidates that this criterion is allowed to return subsets of.
+    pub candidates: RoaringBitmap,
+    /// Candidates that comes from the current bucket of the initial criterion.
+    pub bucket_candidates: RoaringBitmap,
+}
+
 pub struct Fetcher<'t> {
     ctx: &'t dyn Context,
     query_tree: Option<Operation>,
     candidates: Candidates,
     parent: Option<Box<dyn Criterion + 't>>,
     should_get_documents_ids: bool,
+    wdcache: WordDerivationsCache,
 }
 
 impl<'t> Fetcher<'t> {
@@ -29,6 +41,7 @@ impl<'t> Fetcher<'t> {
             candidates: candidates.map_or_else(Candidates::default, Candidates::Allowed),
             parent: None,
             should_get_documents_ids: true,
+            wdcache: WordDerivationsCache::new(),
         }
     }
 
@@ -43,13 +56,12 @@ impl<'t> Fetcher<'t> {
             candidates: Candidates::default(),
             parent: Some(parent),
             should_get_documents_ids: true,
+            wdcache: WordDerivationsCache::new(),
         }
     }
-}
 
-impl<'t> Criterion for Fetcher<'t> {
     #[logging_timer::time("Fetcher::{}")]
-    fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
+    pub fn next(&mut self) -> anyhow::Result<Option<FetcherResult>> {
         use Candidates::{Allowed, Forbidden};
         loop {
             debug!("Fetcher iteration (should_get_documents_ids: {}) ({:?})",
@@ -62,14 +74,14 @@ impl<'t> Criterion for Fetcher<'t> {
                     let candidates = take(&mut self.candidates).into_inner();
                     let candidates = match &self.query_tree {
                         Some(qt) if should_get_documents_ids => {
-                            let mut docids = resolve_query_tree(self.ctx, &qt, &mut HashMap::new(), wdcache)?;
+                            let mut docids = resolve_query_tree(self.ctx, &qt, &mut HashMap::new(), &mut self.wdcache)?;
                             docids.intersect_with(&candidates);
                             docids
                         },
                         _ => candidates,
                     };
 
-                    return Ok(Some(CriterionResult {
+                    return Ok(Some(FetcherResult {
                         query_tree: self.query_tree.take(),
                         candidates: candidates.clone(),
                         bucket_candidates: candidates,
@@ -78,15 +90,23 @@ impl<'t> Criterion for Fetcher<'t> {
                 Forbidden(_) => {
                     match self.parent.as_mut() {
                         Some(parent) => {
-                            match parent.next(wdcache)? {
-                                Some(result) => return Ok(Some(result)),
+                            match parent.next(&mut self.wdcache)? {
+                                Some(CriterionResult { query_tree, candidates, bucket_candidates }) => {
+                                    let candidates = match (&query_tree, candidates) {
+                                        (_, Some(candidates)) => candidates,
+                                        (Some(qt), None) => resolve_query_tree(self.ctx, qt, &mut HashMap::new(), &mut self.wdcache)?,
+                                        (None, None) => RoaringBitmap::new(),
+                                    };
+
+                                    return Ok(Some(FetcherResult { query_tree, candidates, bucket_candidates }))
+                                },
                                 None => if should_get_documents_ids {
                                     let candidates = match &self.query_tree {
-                                        Some(qt) => resolve_query_tree(self.ctx, &qt, &mut HashMap::new(), wdcache)?,
+                                        Some(qt) => resolve_query_tree(self.ctx, &qt, &mut HashMap::new(), &mut self.wdcache)?,
                                         None => self.ctx.documents_ids()?,
                                     };
 
-                                    return Ok(Some(CriterionResult {
+                                    return Ok(Some(FetcherResult {
                                         query_tree: self.query_tree.clone(),
                                         candidates: candidates.clone(),
                                         bucket_candidates: candidates,
@@ -96,11 +116,11 @@ impl<'t> Criterion for Fetcher<'t> {
                         },
                         None => if should_get_documents_ids {
                             let candidates = match &self.query_tree {
-                                Some(qt) => resolve_query_tree(self.ctx, &qt, &mut HashMap::new(), wdcache)?,
+                                Some(qt) => resolve_query_tree(self.ctx, &qt, &mut HashMap::new(), &mut self.wdcache)?,
                                 None => self.ctx.documents_ids()?,
                             };
 
-                            return Ok(Some(CriterionResult {
+                            return Ok(Some(FetcherResult {
                                 query_tree: self.query_tree.clone(),
                                 candidates: candidates.clone(),
                                 bucket_candidates: candidates,

--- a/milli/src/search/criteria/fetcher.rs
+++ b/milli/src/search/criteria/fetcher.rs
@@ -8,12 +8,12 @@ use crate::search::query_tree::Operation;
 use crate::search::WordDerivationsCache;
 use super::{resolve_query_tree, Candidates, Criterion, CriterionResult, Context};
 
-/// The result of a call to the parent criterion.
+/// The result of a call to the fetcher.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FetcherResult {
-    /// The query tree that must be used by the children criterion to fetch candidates.
+    /// The query tree corresponding to the current bucket of the last criterion.
     pub query_tree: Option<Operation>,
-    /// The candidates that this criterion is allowed to return subsets of.
+    /// The candidates of the current bucket of the last criterion.
     pub candidates: RoaringBitmap,
     /// Candidates that comes from the current bucket of the initial criterion.
     pub bucket_candidates: RoaringBitmap,

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -14,10 +14,10 @@ use self::asc_desc::AscDesc;
 use self::proximity::Proximity;
 use self::fetcher::Fetcher;
 
-pub mod typo;
-pub mod words;
-pub mod asc_desc;
-pub mod proximity;
+mod typo;
+mod words;
+mod asc_desc;
+mod proximity;
 pub mod fetcher;
 
 pub trait Criterion {
@@ -28,11 +28,12 @@ pub trait Criterion {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CriterionResult {
     /// The query tree that must be used by the children criterion to fetch candidates.
-    pub query_tree: Option<Operation>,
-    /// The candidates that this criterion is allowed to return subsets of.
-    pub candidates: RoaringBitmap,
+    query_tree: Option<Operation>,
+    /// The candidates that this criterion is allowed to return subsets of,
+    /// if None, it is up to the child to compute the candidates itself.
+    candidates: Option<RoaringBitmap>,
     /// Candidates that comes from the current bucket of the initial criterion.
-    pub bucket_candidates: RoaringBitmap,
+    bucket_candidates: RoaringBitmap,
 }
 
 /// Either a set of candidates that defines the candidates

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -179,10 +179,15 @@ impl<'t> Criterion for Proximity<'t> {
                                         (None, None) => RoaringBitmap::new(),
                                     };
 
+                                    if bucket_candidates.is_empty() {
+                                        self.bucket_candidates.union_with(&candidates);
+                                    } else {
+                                        self.bucket_candidates.union_with(&bucket_candidates);
+                                    }
+
                                     self.query_tree = query_tree.map(|op| (maximum_proximity(&op), op));
                                     self.proximity = 0;
                                     self.candidates = Candidates::Allowed(candidates);
-                                    self.bucket_candidates.union_with(&bucket_candidates);
                                     self.plane_sweep_cache = None;
                                 },
                                 None => return Ok(None),

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -1,14 +1,13 @@
-use std::borrow::Cow;
 use std::collections::btree_map::{self, BTreeMap};
-use std::collections::hash_map::{HashMap, Entry};
+use std::collections::hash_map::HashMap;
 use std::mem::take;
 
 use roaring::RoaringBitmap;
 use log::debug;
 
-use crate::{DocumentId, Position, search::{query_tree::QueryKind, word_derivations}};
+use crate::{DocumentId, Position, search::{query_tree::QueryKind}};
 use crate::search::query_tree::{maximum_proximity, Operation, Query};
-use crate::search::WordDerivationsCache;
+use crate::search::{build_dfa, WordDerivationsCache};
 use super::{Candidates, Criterion, CriterionResult, Context, query_docids, query_pair_proximity_docids, resolve_query_tree};
 
 pub struct Proximity<'t> {
@@ -358,7 +357,7 @@ fn resolve_plane_sweep_candidates(
         docid: DocumentId,
         consecutive: bool,
         rocache: &mut HashMap<&'a Operation, Vec<(Position, u8, Position)>>,
-        dwpcache: &mut HashMap<String, Option<RoaringBitmap>>,
+        words_positions: &HashMap<String, RoaringBitmap>,
         wdcache: &mut WordDerivationsCache,
     ) -> anyhow::Result<Vec<(Position, u8, Position)>>
     {
@@ -400,7 +399,7 @@ fn resolve_plane_sweep_candidates(
         let mut groups_positions = Vec::with_capacity(groups_len);
 
         for operation in operations {
-            let positions = resolve_operation(ctx, operation, docid, rocache, dwpcache, wdcache)?;
+            let positions = resolve_operation(ctx, operation, docid, rocache, words_positions, wdcache)?;
             groups_positions.push(positions.into_iter());
         }
 
@@ -476,7 +475,7 @@ fn resolve_plane_sweep_candidates(
         query_tree: &'a Operation,
         docid: DocumentId,
         rocache: &mut HashMap<&'a Operation, Vec<(Position, u8, Position)>>,
-        dwpcache: &mut HashMap<String, Option<RoaringBitmap>>,
+        words_positions: &HashMap<String, RoaringBitmap>,
         wdcache: &mut WordDerivationsCache,
     ) -> anyhow::Result<Vec<(Position, u8, Position)>>
     {
@@ -487,44 +486,34 @@ fn resolve_plane_sweep_candidates(
         }
 
         let result = match query_tree {
-            And(ops) => plane_sweep(ctx, ops, docid, false, rocache, dwpcache, wdcache)?,
-            Consecutive(ops) => plane_sweep(ctx, ops, docid, true, rocache, dwpcache, wdcache)?,
+            And(ops) => plane_sweep(ctx, ops, docid, false, rocache, words_positions, wdcache)?,
+            Consecutive(ops) => plane_sweep(ctx, ops, docid, true, rocache, words_positions, wdcache)?,
             Or(_, ops) => {
                 let mut result = Vec::new();
                 for op in ops {
-                    result.extend(resolve_operation(ctx, op, docid, rocache, dwpcache, wdcache)?)
+                    result.extend(resolve_operation(ctx, op, docid, rocache, words_positions, wdcache)?)
                 }
 
                 result.sort_unstable();
                 result
             },
-            Operation::Query(Query {prefix, kind}) => {
-                let fst = ctx.words_fst();
-                let words = match kind {
+            Operation::Query(Query { prefix, kind }) => {
+                let mut result = Vec::new();
+                match kind {
                     QueryKind::Exact { word, .. } => {
                         if *prefix {
-                            Cow::Borrowed(word_derivations(word, true, 0, fst, wdcache)?)
+                            let iter = word_derivations(word, true, 0, &words_positions)
+                                .flat_map(|positions| positions.iter().map(|p| (p, 0, p)));
+                            result.extend(iter);
                         } else {
-                            Cow::Owned(vec![(word.to_string(), 0)])
+                            if let Some(positions) = words_positions.get(word) {
+                                result.extend(positions.iter().map(|p| (p, 0, p)));
+                            }
                         }
                     },
                     QueryKind::Tolerant { typo, word } => {
-                        Cow::Borrowed(word_derivations(word, *prefix, *typo, fst, wdcache)?)
-                    }
-                };
-
-                let mut result = Vec::new();
-                for (word, _) in words.as_ref() {
-                    let positions = match dwpcache.entry(word.to_string()) {
-                        Entry::Occupied(entry) => entry.into_mut(),
-                        Entry::Vacant(entry) => {
-                            let positions = ctx.docid_word_positions(docid, word)?;
-                            entry.insert(positions)
-                        }
-                    };
-
-                    if let Some(positions) = positions {
-                        let iter = positions.iter().map(|p| (p, 0, p));
+                        let iter = word_derivations(word, *prefix, *typo, &words_positions)
+                            .flat_map(|positions| positions.iter().map(|p| (p, 0, p)));
                         result.extend(iter);
                     }
                 }
@@ -538,18 +527,34 @@ fn resolve_plane_sweep_candidates(
         Ok(result)
     }
 
-    let mut word_positions_cache = HashMap::new();
+    fn word_derivations<'a>(
+        word: &str,
+        is_prefix: bool,
+        max_typo: u8,
+        words_positions: &'a HashMap<String, RoaringBitmap>,
+    ) -> impl Iterator<Item = &'a RoaringBitmap>
+    {
+        let dfa = build_dfa(word, max_typo, is_prefix);
+        words_positions.iter().filter_map(move |(document_word, positions)| {
+            use levenshtein_automata::Distance;
+            match dfa.eval(document_word) {
+                Distance::Exact(_) => Some(positions),
+                Distance::AtLeast(_) => None,
+            }
+        })
+    }
+
     let mut resolve_operation_cache = HashMap::new();
     let mut candidates = BTreeMap::new();
     for docid in allowed_candidates {
-        word_positions_cache.clear();
+        let words_positions = ctx.docid_words_positions(docid)?;
         resolve_operation_cache.clear();
         let positions =  resolve_operation(
             ctx,
             query_tree,
             docid,
             &mut resolve_operation_cache,
-            &mut word_positions_cache,
+            &words_positions,
             wdcache,
         )?;
         let best_proximity = positions.into_iter().min_by_key(|(_, proximity, _)| *proximity);

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -63,7 +63,7 @@ impl<'t> Criterion for Typo<'t> {
                 (_, Allowed(candidates)) if candidates.is_empty() => {
                     return Ok(Some(CriterionResult {
                         query_tree: self.query_tree.take().map(|(_, qt)| qt),
-                        candidates: take(&mut self.candidates).into_inner(),
+                        candidates: Some(take(&mut self.candidates).into_inner()),
                         bucket_candidates: take(&mut self.bucket_candidates),
                     }));
                 },
@@ -100,7 +100,7 @@ impl<'t> Criterion for Typo<'t> {
 
                         return Ok(Some(CriterionResult {
                             query_tree: Some(new_query_tree),
-                            candidates: new_candidates,
+                            candidates: Some(new_candidates),
                             bucket_candidates,
                         }));
                     }
@@ -138,7 +138,7 @@ impl<'t> Criterion for Typo<'t> {
 
                         return Ok(Some(CriterionResult {
                             query_tree: Some(new_query_tree),
-                            candidates: new_candidates,
+                            candidates: Some(new_candidates),
                             bucket_candidates,
                         }));
                     }
@@ -147,7 +147,7 @@ impl<'t> Criterion for Typo<'t> {
                     let candidates = take(&mut self.candidates).into_inner();
                     return Ok(Some(CriterionResult {
                         query_tree: None,
-                        candidates: candidates.clone(),
+                        candidates: Some(candidates.clone()),
                         bucket_candidates: candidates,
                     }));
                 },
@@ -158,7 +158,7 @@ impl<'t> Criterion for Typo<'t> {
                                 Some(CriterionResult { query_tree, candidates, bucket_candidates }) => {
                                     self.query_tree = query_tree.map(|op| (maximum_typo(&op), op));
                                     self.number_typos = 0;
-                                    self.candidates = Candidates::Allowed(candidates);
+                                    self.candidates = candidates.map_or_else(Candidates::default, Candidates::Allowed);
                                     self.bucket_candidates.union_with(&bucket_candidates);
                                 },
                                 None => return Ok(None),
@@ -394,7 +394,7 @@ mod test {
                     Operation::Query(Query { prefix: false, kind: QueryKind::exact("world".to_string()) }),
                 ]),
             ])),
-            candidates: candidates_1.clone(),
+            candidates: Some(candidates_1.clone()),
             bucket_candidates: candidates_1,
         };
 
@@ -416,7 +416,7 @@ mod test {
                     ]),
                 ]),
             ])),
-            candidates: candidates_2.clone(),
+            candidates: Some(candidates_2.clone()),
             bucket_candidates: candidates_2,
         };
 
@@ -434,7 +434,7 @@ mod test {
 
         let expected = CriterionResult {
             query_tree: None,
-            candidates: facet_candidates.clone(),
+            candidates: Some(facet_candidates.clone()),
             bucket_candidates: facet_candidates,
         };
 
@@ -472,7 +472,7 @@ mod test {
                     Operation::Query(Query { prefix: false, kind: QueryKind::exact("world".to_string()) }),
                 ]),
             ])),
-            candidates: &candidates_1 & &facet_candidates,
+            candidates: Some(&candidates_1 & &facet_candidates),
             bucket_candidates: candidates_1 & &facet_candidates,
         };
 
@@ -494,7 +494,7 @@ mod test {
                     ]),
                 ]),
             ])),
-            candidates: &candidates_2 & &facet_candidates,
+            candidates: Some(&candidates_2 & &facet_candidates),
             bucket_candidates: candidates_2 & &facet_candidates,
         };
 

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -127,16 +127,12 @@ impl<'t> Criterion for Typo<'t> {
                         new_candidates.difference_with(&candidates);
                         candidates.union_with(&new_candidates);
                         self.number_typos += 1;
-
-                        let bucket_candidates = match self.parent {
-                            Some(_) => take(&mut self.bucket_candidates),
-                            None => new_candidates.clone(),
-                        };
+                        self.bucket_candidates.union_with(&new_candidates);
 
                         return Ok(Some(CriterionResult {
                             query_tree: Some(new_query_tree),
                             candidates: Some(new_candidates),
-                            bucket_candidates,
+                            bucket_candidates: take(&mut self.bucket_candidates),
                         }));
                     }
                 },

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -33,13 +33,24 @@ pub struct Search<'a> {
     facet_condition: Option<FacetCondition>,
     offset: usize,
     limit: usize,
+    optional_words: bool,
+    authorize_typos: bool,
     rtxn: &'a heed::RoTxn<'a>,
     index: &'a Index,
 }
 
 impl<'a> Search<'a> {
     pub fn new(rtxn: &'a heed::RoTxn, index: &'a Index) -> Search<'a> {
-        Search { query: None, facet_condition: None, offset: 0, limit: 20, rtxn, index }
+        Search {
+            query: None,
+            facet_condition: None,
+            offset: 0,
+            limit: 20,
+            optional_words: true,
+            authorize_typos: true,
+            rtxn,
+            index,
+        }
     }
 
     pub fn query(&mut self, query: impl Into<String>) -> &mut Search<'a> {
@@ -57,6 +68,16 @@ impl<'a> Search<'a> {
         self
     }
 
+    pub fn optional_words(&mut self, value: bool) -> &mut Search<'a> {
+        self.optional_words = value;
+        self
+    }
+
+    pub fn authorize_typos(&mut self, value: bool) -> &mut Search<'a> {
+        self.authorize_typos = value;
+        self
+    }
+
     pub fn facet_condition(&mut self, condition: FacetCondition) -> &mut Search<'a> {
         self.facet_condition = Some(condition);
         self
@@ -67,7 +88,9 @@ impl<'a> Search<'a> {
         let before = Instant::now();
         let query_tree = match self.query.as_ref() {
             Some(query) => {
-                let builder = QueryTreeBuilder::new(self.rtxn, self.index);
+                let mut builder = QueryTreeBuilder::new(self.rtxn, self.index);
+                builder.optional_words(self.optional_words);
+                builder.authorize_typos(self.authorize_typos);
                 let stop_words = &Set::default();
                 let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(stop_words));
                 let result = analyzer.analyze(query);
@@ -129,12 +152,23 @@ impl<'a> Search<'a> {
 
 impl fmt::Debug for Search<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Search { query, facet_condition, offset, limit, rtxn: _, index: _ } = self;
+        let Search {
+            query,
+            facet_condition,
+            offset,
+            limit,
+            optional_words,
+            authorize_typos,
+            rtxn: _,
+            index: _,
+        } = self;
         f.debug_struct("Search")
             .field("query", query)
             .field("facet_condition", facet_condition)
             .field("offset", offset)
             .field("limit", limit)
+            .field("optional_words", optional_words)
+            .field("authorize_typos", authorize_typos)
             .finish()
     }
 }

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -11,7 +11,7 @@ use meilisearch_tokenizer::{AnalyzerConfig, Analyzer};
 use once_cell::sync::Lazy;
 use roaring::bitmap::RoaringBitmap;
 
-use crate::search::criteria::{Criterion, CriterionResult};
+use crate::search::criteria::fetcher::FetcherResult;
 use crate::{Index, DocumentId};
 
 pub use self::facet::FacetIter;
@@ -99,9 +99,8 @@ impl<'a> Search<'a> {
         let mut offset = self.offset;
         let mut limit = self.limit;
         let mut documents_ids = Vec::new();
-        let mut words_derivations_cache = WordDerivationsCache::new();
         let mut initial_candidates = RoaringBitmap::new();
-        while let Some(CriterionResult { candidates, bucket_candidates, .. }) = criteria.next(&mut words_derivations_cache)? {
+        while let Some(FetcherResult { candidates, bucket_candidates, .. }) = criteria.next()? {
 
             debug!("Number of candidates found {}", candidates.len());
 


### PR DESCRIPTION
This PR changes the words criterion to avoid computing the candidate, it now directly gives the query tree to its child. It also introduces a new way of fetching words derivations in the proximity criterion when the number of candidates is small reducing some queries from 1.2s to 144ms 🎉