### PR TITLE
fix broken offset

### DIFF
--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -133,7 +133,7 @@ impl<'a> Search<'a> {
             initial_candidates.union_with(&bucket_candidates);
 
             if offset != 0 {
-                candidates.by_ref().skip(offset).for_each(drop);
+                candidates.by_ref().take(offset).for_each(drop);
                 offset = offset.saturating_sub(len.min(offset));
                 len = len.saturating_sub(len.min(offset));
             }


### PR DESCRIPTION
 Fix broken offset. 'skip' was used instead of `take` on the candidate iterator, so `for_each` would consume all of the iterator, instead of only the `offset` first.

fix https://github.com/meilisearch/transplant/issues/82