### PR TITLE
Add release drafter files

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -1,0 +1,27 @@
+name-template: 'Milli v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  minor:
+    labels:
+      - 'breaking-change'
+  default: patch
+categories:
+  - title: 'Breaking changes ⚠️'
+    label: 'breaking-change'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  Thanks again to $CONTRIBUTORS! 🎉
+no-changes-template: 'Changes are coming soon 😎'
+sort-direction: 'ascending'
+replacers:
+  - search: '/(?:and )?@dependabot-preview(?:\[bot\])?,?/g'
+    replace: ''
+  - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
+    replace: ''
+  - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-draft-template.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}


### PR DESCRIPTION
3 rules:
- if you don't want a PR to appear in the release (ex: a typo fix), add the label `skip-changelog` to the PR
- if the PR involves breaking changes, add the `breaking-change` label to the PR -> the minor version (because we are currently in v0.X.Y) will be automatically increased and the PR title will be put in the "Breaking Changes" section of the release description
- to do a release, just create a release in the `Release` section in GitHub (don't push any tag)
<img width="1364" alt="Capture d’écran 2021-04-08 à 19 35 44" src="https://user-images.githubusercontent.com/20380692/114071783-d07de400-98a1-11eb-84c0-612547c6c925.png">

And of course, the secret `RELEASE_DRAFTER_TOKEN` is added to the repo