### PR TITLE
feat(search, update): synonyms

### DIFF
--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -260,6 +260,9 @@ struct Settings {
 
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     stop_words: Setting<BTreeSet<String>>,
+
+    #[serde(default, skip_serializing_if = "Setting::is_not_set")]
+    synonyms: Setting<HashMap<String, Vec<String>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -428,6 +431,13 @@ async fn main() -> anyhow::Result<()> {
                     match settings.stop_words {
                         Setting::Set(stop_words) => builder.set_stop_words(stop_words),
                         Setting::Reset => builder.reset_stop_words(),
+                        Setting::NotSet => ()
+                    }
+
+                    // We transpose the settings JSON struct into a real setting update.
+                    match settings.synonyms {
+                        Setting::Set(synonyms) => builder.set_synonyms(synonyms),
+                        Setting::Reset => builder.reset_synonyms(),
                         Setting::NotSet => ()
                     }
 
@@ -1011,6 +1021,7 @@ mod tests {
             faceted_attributes: Setting::Set(hashmap! { "age".into() => "integer".into() }),
             criteria: Setting::Set(vec!["asc(age)".to_string()]),
             stop_words: Setting::Set(btreeset! { "and".to_string() }),
+            synonyms: Setting::NotSet
         };
 
         assert_tokens(&settings, &[
@@ -1053,6 +1064,7 @@ mod tests {
             faceted_attributes: Setting::Reset,
             criteria: Setting::Reset,
             stop_words: Setting::Reset,
+            synonyms: Setting::NotSet
         };
 
         assert_tokens(&settings, &[

--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -1021,11 +1021,11 @@ mod tests {
             faceted_attributes: Setting::Set(hashmap! { "age".into() => "integer".into() }),
             criteria: Setting::Set(vec!["asc(age)".to_string()]),
             stop_words: Setting::Set(btreeset! { "and".to_string() }),
-            synonyms: Setting::NotSet
+            synonyms: Setting::Set(hashmap! { "alex".to_string() => vec!["alexey".to_string()] })
         };
 
         assert_tokens(&settings, &[
-            Token::Struct { name: "Settings", len: 5 },
+            Token::Struct { name: "Settings", len: 6 },
             Token::Str("displayedAttributes"),
             Token::Some,
             Token::Seq { len: Some(1) },
@@ -1052,6 +1052,14 @@ mod tests {
             Token::Seq { len: Some(1) },
             Token::Str("and"),
             Token::SeqEnd,
+            Token::Str("synonyms"),
+            Token::Some,
+            Token::Map { len: Some(1) },
+            Token::Str("alex"),
+            Token::Seq {len: Some(1) },
+            Token::Str("alexey"),
+            Token::SeqEnd,
+            Token::MapEnd,
             Token::StructEnd,
         ]);
     }
@@ -1064,11 +1072,11 @@ mod tests {
             faceted_attributes: Setting::Reset,
             criteria: Setting::Reset,
             stop_words: Setting::Reset,
-            synonyms: Setting::NotSet
+            synonyms: Setting::Reset,
         };
 
         assert_tokens(&settings, &[
-            Token::Struct { name: "Settings", len: 5 },
+            Token::Struct { name: "Settings", len: 6 },
             Token::Str("displayedAttributes"),
             Token::None,
             Token::Str("searchableAttributes"),
@@ -1078,6 +1086,8 @@ mod tests {
             Token::Str("criteria"),
             Token::None,
             Token::Str("stopWords"),
+            Token::None,
+            Token::Str("synonyms"),
             Token::None,
             Token::StructEnd,
         ]);
@@ -1091,6 +1101,7 @@ mod tests {
             faceted_attributes: Setting::NotSet,
             criteria: Setting::NotSet,
             stop_words: Setting::NotSet,
+            synonyms: Setting::NotSet,
         };
 
         assert_tokens(&settings, &[

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -3,19 +3,19 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Context;
+use chrono::{DateTime, Utc};
+use heed::{Database, PolyDatabase, RoTxn, RwTxn};
 use heed::types::*;
-use heed::{PolyDatabase, Database, RwTxn, RoTxn};
 use roaring::RoaringBitmap;
-use chrono::{Utc, DateTime};
 
+use crate::{Criterion, default_criteria, FacetDistribution, FieldsDistribution, Search};
+use crate::{BEU32, DocumentId, ExternalDocumentsIds, FieldId};
+use crate::{
+    BEU32StrCodec, BoRoaringBitmapCodec, CboRoaringBitmapCodec,
+    ObkvCodec, RoaringBitmapCodec, RoaringBitmapLenCodec, StrStrU8Codec,
+};
 use crate::facet::FacetType;
 use crate::fields_ids_map::FieldsIdsMap;
-use crate::{default_criteria, Criterion, Search, FacetDistribution, FieldsDistribution};
-use crate::{BEU32, DocumentId, FieldId, ExternalDocumentsIds};
-use crate::{
-    RoaringBitmapCodec, RoaringBitmapLenCodec, BEU32StrCodec,
-    StrStrU8Codec, ObkvCodec, BoRoaringBitmapCodec, CboRoaringBitmapCodec,
-};
 
 pub const CRITERIA_KEY: &str = "criteria";
 pub const DISPLAYED_FIELDS_KEY: &str = "displayed-fields";
@@ -30,6 +30,7 @@ pub const HARD_EXTERNAL_DOCUMENTS_IDS_KEY: &str = "hard-external-documents-ids";
 pub const SOFT_EXTERNAL_DOCUMENTS_IDS_KEY: &str = "soft-external-documents-ids";
 pub const WORDS_FST_KEY: &str = "words-fst";
 pub const STOP_WORDS_KEY: &str = "stop-words";
+pub const SYNONYMS_KEY: &str = "synonyms";
 pub const WORDS_PREFIXES_FST_KEY: &str = "words-prefixes-fst";
 const CREATED_AT_KEY: &str = "created-at";
 const UPDATED_AT_KEY: &str = "updated-at";
@@ -361,12 +362,12 @@ impl Index {
 
     /* words fst */
 
-    /// Writes the FST which is the words dictionnary of the engine.
+    /// Writes the FST which is the words dictionary of the engine.
     pub fn put_words_fst<A: AsRef<[u8]>>(&self, wtxn: &mut RwTxn, fst: &fst::Set<A>) -> heed::Result<()> {
         self.main.put::<_, Str, ByteSlice>(wtxn, WORDS_FST_KEY, fst.as_fst().as_bytes())
     }
 
-    /// Returns the FST which is the words dictionnary of the engine.
+    /// Returns the FST which is the words dictionary of the engine.
     pub fn words_fst<'t>(&self, rtxn: &'t RoTxn) -> anyhow::Result<fst::Set<Cow<'t, [u8]>>> {
         match self.main.get::<_, Str, ByteSlice>(rtxn, WORDS_FST_KEY)? {
             Some(bytes) => Ok(fst::Set::new(bytes)?.map_data(Cow::Borrowed)?),
@@ -383,10 +384,39 @@ impl Index {
     pub fn delete_stop_words(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, STOP_WORDS_KEY)
     }
+
     pub fn stop_words<'t>(&self, rtxn: &'t RoTxn) -> anyhow::Result<Option<fst::Set<&'t [u8]>>> {
         match self.main.get::<_, Str, ByteSlice>(rtxn, STOP_WORDS_KEY)? {
             Some(bytes) => Ok(Some(fst::Set::new(bytes)?)),
             None => Ok(None),
+        }
+    }
+
+    /* synonyms */
+
+    pub fn put_synonyms(&self, wtxn: &mut RwTxn, synonyms: &HashMap<Vec<String>, Vec<Vec<String>>>) -> heed::Result<()> {
+        self.main.put::<_, Str, SerdeBincode<_>>(wtxn, SYNONYMS_KEY, synonyms)
+    }
+
+    pub fn delete_synonyms(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+        self.main.delete::<_, Str>(wtxn, SYNONYMS_KEY)
+    }
+
+    pub fn synonyms(&self, rtxn: &RoTxn) -> anyhow::Result<Option<HashMap<Vec<String>, Vec<Vec<String>>>>> {
+        match self.main.get::<_, Str, SerdeBincode<HashMap<Vec<String>, Vec<Vec<String>>>>>(rtxn, SYNONYMS_KEY)? {
+            Some(synonyms) => Ok(Some(synonyms)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn words_synonyms<S: AsRef<str>>(&self, rtxn: &RoTxn, words: &[S]) -> anyhow::Result<Option<Vec<Vec<String>>>> {
+        let words: Vec<_> = words.iter().map(|s| s.as_ref().to_string()).collect();
+
+        match self.synonyms(rtxn)? {
+            Some(synonyms) => Ok(Some(
+                synonyms.get(&words).cloned().unwrap_or(Vec::default())
+            )),
+            None => Ok(None)
         }
     }
 
@@ -490,7 +520,7 @@ mod tests {
         let rtxn = index.read_txn().unwrap();
 
         let fields_distribution = index.fields_distribution(&rtxn).unwrap();
-        assert_eq!(fields_distribution, hashmap!{
+        assert_eq!(fields_distribution, hashmap! {
             "name".to_string() => 2,
             "age".to_string() => 1,
         });


### PR DESCRIPTION
Resolves https://github.com/meilisearch/milli/issues/144

---

First implementation, need to find a better way to store synonyms in future.

```console
➜ milli (shekhirin/synonyms) ✗ curl -H 'Content-Type: application/json' -d '{"synonyms": { "NYC": [ "New York", "New York City" ], "New York": [ "NYC", "New York City" ], "New York City": [ "NYC", "New York" ] }}' 127.0.0.1:9700/settings

➜ milli (shekhirin/synonyms) ✗ curl -H 'Content-Type: application/json' -d '{ "query": "" }' 127.0.0.1:9700/query | jq
{
  "documents": [
    {
      "city": "New York",
      "id": "15c403fa-b658-490a-ad07-1c9e41b7fd41",
      "country": "USA"
    },
    {
      "city": "Moscow",
      "id": "46abe926-5da0-4e11-b9a5-3496da077126",
      "country": "Russia"
    },
    {
      "city": "Paris",
      "id": "d3533315-1272-412a-84f1-cbeaf462e094",
      "country": "France"
    }
  ],
  "numberOfCandidates": 3,
  "facets": {}
}

➜ milli (shekhirin/synonyms) ✗ curl -H 'Content-Type: application/json' -d '{ "query": "nyc" }' 127.0.0.1:9700/query | jq
{
  "documents": [
    {
      "city": "<mark>New</mark> <mark>York</mark>",
      "id": "15c403fa-b658-490a-ad07-1c9e41b7fd41",
      "country": "USA"
    }
  ],
  "numberOfCandidates": 1,
  "facets": {}
}
```
