### PR TITLE
test(http): fix and refactor settings assert_(ser|de)_tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
  "grenad",
  "heed",
  "log",
+ "maplit",
  "meilisearch-tokenizer",
  "memmap",
  "milli",

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -39,4 +39,5 @@ fst = "0.4.5"
 funty = "=1.1"
 
 [dev-dependencies]
+maplit = "1.0.2"
 serde_test = "1.0.125"


### PR DESCRIPTION
Test doesn't pass after merging https://github.com/meilisearch/milli/pull/148

```console
➜ http-ui (main) ✗ cargo test                                
   Compiling http-ui v0.1.0 (/Users/shekhirin/Projects/milli/http-ui)
    Finished test [unoptimized + debuginfo] target(s) in 3.35s
     Running /Users/shekhirin/Projects/milli/target/debug/deps/http_ui-462c80964d4c5a0b

running 2 tests
test tests::deserialize_settings ... ok
test tests::serialize_settings ... FAILED

failures:

---- tests::serialize_settings stdout ----
thread 'tests::serialize_settings' panicked at 'expected Token::Struct { name: "Settings", len: 3 } but serialized as Struct { name: "Settings", len: 2, }', /Users/shekhirin/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_test-1.0.125/src/ser.rs:280:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::serialize_settings

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass '--bin http-ui'
```

---

I've changed the `searchable_attributes` field to behave like others but didn't change the test accordingly. Since all fields have same behavior, we can now use single `assert_tokens` instead of separate `assert_ser_tokens` and `assert_de_tokens` to test serde serialization/deserialization