### PR TITLE
Update Tokenizer version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,8 +1207,8 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "meilisearch-tokenizer"
-version = "0.1.1"
-source = "git+https://github.com/meilisearch/Tokenizer.git?tag=v0.2.0#833c48b2ee39071f8b4f51abd15122afdb3c8c06"
+version = "0.2.1"
+source = "git+https://github.com/meilisearch/Tokenizer.git?tag=v0.2.1#b7a89c682b9f5d23a1d8075a99cca76069fff6c6"
 dependencies = [
  "character_converter",
  "cow-utils",

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.38"
 byte-unit = { version = "4.0.9", default-features = false, features = ["std"] }
 grenad = { git = "https://github.com/Kerollmops/grenad.git", rev = "3adcb26" }
 heed = "0.10.6"
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/Tokenizer.git", tag = "v0.2.0" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/Tokenizer.git", tag = "v0.2.1" }
 memmap = "0.7.0"
 milli = { path = "../milli" }
 once_cell = "1.5.2"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -20,7 +20,7 @@ heed = { version = "0.10.6", default-features = false, features = ["lmdb", "sync
 human_format = "1.0.3"
 levenshtein_automata = { version = "0.2.0", features = ["fst_automaton"] }
 linked-hash-map = "0.5.4"
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/Tokenizer.git", tag = "v0.2.0" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/Tokenizer.git", tag = "v0.2.1" }
 memmap = "0.7.0"
 num-traits = "0.2.14"
 obkv = "0.1.1"


### PR DESCRIPTION
https://github.com/meilisearch/Tokenizer/releases/tag/v0.2.1