### PR TITLE
Optimize roaring codec

### DIFF
--- a/milli/src/heed_codec/roaring_bitmap/bo_roaring_bitmap_codec.rs
+++ b/milli/src/heed_codec/roaring_bitmap/bo_roaring_bitmap_codec.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::mem::size_of;
 
-use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use roaring::RoaringBitmap;
 
 pub struct BoRoaringBitmapCodec;
@@ -11,14 +11,12 @@ impl heed::BytesDecode<'_> for BoRoaringBitmapCodec {
 
     fn bytes_decode(bytes: &[u8]) -> Option<Self::DItem> {
         let mut bitmap = RoaringBitmap::new();
-        let num_u32 = bytes.len() / size_of::<u32>();
-        for i in 0..num_u32 {
-            let start = i * size_of::<u32>();
-            let end = (i + 1) * size_of::<u32>();
-            let mut bytes = bytes.get(start..end)?;
-            let integer = bytes.read_u32::<NativeEndian>().ok()?;
-            bitmap.insert(integer);
+
+        for chunk in bytes.chunks(size_of::<u32>()) {
+            let bytes = chunk.try_into().ok()?;
+            bitmap.push(u32::from_ne_bytes(bytes));
         }
+
         Some(bitmap)
     }
 }
@@ -27,10 +25,12 @@ impl heed::BytesEncode<'_> for BoRoaringBitmapCodec {
     type EItem = RoaringBitmap;
 
     fn bytes_encode(item: &Self::EItem) -> Option<Cow<[u8]>> {
-        let mut bytes = Vec::with_capacity(item.len() as usize * 4);
-        for integer in item.iter() {
-            bytes.write_u32::<NativeEndian>(integer).ok()?;
-        }
-        Some(Cow::Owned(bytes))
+        let mut out = Vec::with_capacity(item.len() as usize * size_of::<u32>());
+
+        item.iter()
+            .map(|i| i.to_ne_bytes())
+            .for_each(|bytes| out.extend_from_slice(&bytes));
+
+        Some(Cow::Owned(out))
     }
 }


### PR DESCRIPTION
Optimize the `BoRoaringBitmapCodec` by preventing it from emiting useless error that caused allocation. On my flamegraph, the byte_decode function went from 4.13% to  1.70% (of transplant graph).

This may not be the greatest optimization ever, but hey, this was a low hanging fruit.

before:
![image](https://user-images.githubusercontent.com/28804882/116241125-17018880-a754-11eb-9f9d-a67418d100e1.png)
after:
![image](https://user-images.githubusercontent.com/28804882/116241167-21bc1d80-a754-11eb-9afc-d9d72727477c.png)

