### PR TITLE
Remove excluded document in criteria iterations

### DIFF
--- a/milli/src/search/criteria/final.rs
+++ b/milli/src/search/criteria/final.rs
@@ -5,7 +5,7 @@ use roaring::RoaringBitmap;
 
 use crate::search::query_tree::Operation;
 use crate::search::WordDerivationsCache;
-use super::{resolve_query_tree, Criterion, CriterionResult, Context};
+use super::{resolve_query_tree, Criterion, CriterionResult, CriterionParameters, Context};
 
 /// The result of a call to the fetcher.
 #[derive(Debug, Clone, PartialEq)]
@@ -22,27 +22,39 @@ pub struct Final<'t> {
     ctx: &'t dyn Context<'t>,
     parent: Box<dyn Criterion + 't>,
     wdcache: WordDerivationsCache,
+    returned_candidates: RoaringBitmap,
 }
 
 impl<'t> Final<'t> {
     pub fn new(ctx: &'t dyn Context<'t>, parent: Box<dyn Criterion + 't>) -> Final<'t> {
-        Final { ctx, parent, wdcache: WordDerivationsCache::new() }
+        Final { ctx, parent, wdcache: WordDerivationsCache::new(), returned_candidates: RoaringBitmap::new() }
     }
 
     #[logging_timer::time("Final::{}")]
-    pub fn next(&mut self) -> anyhow::Result<Option<FinalResult>> {
+    pub fn next(&mut self, excluded_candidates: &RoaringBitmap) -> anyhow::Result<Option<FinalResult>> {
         loop {
             debug!("Final iteration");
+            let mut criterion_parameters = CriterionParameters {
+                wdcache: &mut self.wdcache,
+                // returned_candidates is merged with excluded_candidates to avoid duplicas
+                excluded_candidates: &(&self.returned_candidates | excluded_candidates),
+            };
 
-            match self.parent.next(&mut self.wdcache)? {
+            match self.parent.next(&mut criterion_parameters)? {
                 Some(CriterionResult { query_tree, candidates, mut bucket_candidates }) => {
-                    let candidates = match (&query_tree, candidates) {
-                        (_, Some(candidates)) => candidates,
-                        (Some(qt), None) => resolve_query_tree(self.ctx, qt, &mut HashMap::new(), &mut self.wdcache)?,
-                        (None, None) => self.ctx.documents_ids()?,
+                    let candidates = match candidates {
+                        Some(candidates) => candidates,
+                        None => {
+                            let candidates = match query_tree.as_ref() {
+                                Some(qt) => resolve_query_tree(self.ctx, qt, &mut HashMap::new(), &mut self.wdcache)?,
+                                None => self.ctx.documents_ids()?,
+                            };
+                            bucket_candidates |= &candidates;
+                            candidates
+                        }
                     };
 
-                    bucket_candidates.union_with(&candidates);
+                    self.returned_candidates |= &candidates;
 
                     return Ok(Some(FinalResult { query_tree, candidates, bucket_candidates }));
                 },

--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -1,9 +1,8 @@
 use roaring::RoaringBitmap;
 
 use crate::search::query_tree::Operation;
-use crate::search::WordDerivationsCache;
 
-use super::{Criterion, CriterionResult};
+use super::{Criterion, CriterionResult, CriterionParameters};
 
 pub struct Initial {
     answer: Option<CriterionResult>
@@ -22,7 +21,7 @@ impl Initial {
 
 impl Criterion for Initial {
     #[logging_timer::time("Initial::{}")]
-    fn next(&mut self, _: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>> {
+    fn next(&mut self, _: &mut CriterionParameters) -> anyhow::Result<Option<CriterionResult>> {
         Ok(self.answer.take())
     }
 }

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -25,7 +25,7 @@ mod words;
 pub mod r#final;
 
 pub trait Criterion {
-    fn next(&mut self, wdcache: &mut WordDerivationsCache) -> anyhow::Result<Option<CriterionResult>>;
+    fn next(&mut self, params: &mut CriterionParameters) -> anyhow::Result<Option<CriterionResult>>;
 }
 
 /// The result of a call to the parent criterion.
@@ -38,6 +38,12 @@ pub struct CriterionResult {
     candidates: Option<RoaringBitmap>,
     /// Candidates that comes from the current bucket of the initial criterion.
     bucket_candidates: RoaringBitmap,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct CriterionParameters<'a> {
+    wdcache: &'a mut WordDerivationsCache,
+    excluded_candidates: &'a RoaringBitmap,
 }
 
 /// Either a set of candidates that defines the candidates


### PR DESCRIPTION
- pass excluded document to criteria to remove them in higher levels of the bucket-sort
- merge already returned document with excluded documents to avoid duplicas

Related to #125 and #112
Fix #170