### PR TITLE
make document addition number visible

### DIFF
--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -41,7 +41,7 @@ mod transform;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DocumentAdditionResult {
-    nb_documents: usize,
+    pub nb_documents: usize,
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
The `nb_document` needs to be public to allow the conversion of update statuses to the legacy meilisearch format.
