### PR TITLE
Transfer numbers and strings facets into the appropriate facet databases

### DIFF
--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -30,7 +30,6 @@ use warp::{Filter, http::Response};
 use warp::filters::ws::Message;
 
 use milli::{FacetCondition, Index, MatchingWords, obkv_to_json, SearchResult, UpdateStore};
-use milli::facet::FacetValue;
 use milli::update::{IndexDocumentsMethod, Setting, UpdateBuilder, UpdateFormat};
 use milli::update::UpdateIndexingStep::*;
 
@@ -252,7 +251,7 @@ struct Settings {
     searchable_attributes: Setting<Vec<String>>,
 
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
-    faceted_attributes: Setting<HashMap<String, String>>,
+    faceted_attributes: Setting<HashSet<String>>,
 
     #[serde(default, skip_serializing_if = "Setting::is_not_set")]
     criteria: Setting<Vec<String>>,
@@ -671,7 +670,7 @@ async fn main() -> anyhow::Result<()> {
     struct Answer {
         documents: Vec<Map<String, Value>>,
         number_of_candidates: u64,
-        facets: BTreeMap<String, BTreeMap<FacetValue, u64>>,
+        facets: BTreeMap<String, BTreeMap<String, u64>>,
     }
 
     let disable_highlighting = opt.disable_highlighting;
@@ -985,7 +984,7 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use maplit::{btreeset,hashmap};
+    use maplit::{btreeset,hashmap, hashset};
     use serde_test::{assert_tokens, Token};
 
     use milli::update::Setting;
@@ -997,10 +996,10 @@ mod tests {
         let settings = Settings {
             displayed_attributes: Setting::Set(vec!["name".to_string()]),
             searchable_attributes: Setting::Set(vec!["age".to_string()]),
-            faceted_attributes: Setting::Set(hashmap! { "age".into() => "integer".into() }),
+            faceted_attributes: Setting::Set(hashset!{ "age".to_string() }),
             criteria: Setting::Set(vec!["asc(age)".to_string()]),
             stop_words: Setting::Set(btreeset! { "and".to_string() }),
-            synonyms: Setting::Set(hashmap! { "alex".to_string() => vec!["alexey".to_string()] })
+            synonyms: Setting::Set(hashmap!{ "alex".to_string() => vec!["alexey".to_string()] })
         };
 
         assert_tokens(&settings, &[

--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 
 use anyhow::{Context, bail};
 use regex::Regex;
 use serde::{Serialize, Deserialize};
 use once_cell::sync::Lazy;
-
-use crate::facet::FacetType;
 
 static ASC_DESC_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r#"(asc|desc)\(([\w_-]+)\)"#).unwrap()
@@ -33,7 +31,7 @@ pub enum Criterion {
 }
 
 impl Criterion {
-    pub fn from_str(faceted_attributes: &HashMap<String, FacetType>, txt: &str) -> anyhow::Result<Criterion> {
+    pub fn from_str(faceted_attributes: &HashSet<String>, txt: &str) -> anyhow::Result<Criterion> {
         match txt {
             "words" => Ok(Criterion::Words),
             "typo" => Ok(Criterion::Typo),
@@ -44,7 +42,9 @@ impl Criterion {
                 let caps = ASC_DESC_REGEX.captures(text).with_context(|| format!("unknown criterion name: {}", text))?;
                 let order = caps.get(1).unwrap().as_str();
                 let field_name = caps.get(2).unwrap().as_str();
-                faceted_attributes.get(field_name).with_context(|| format!("Can't use {:?} as a criterion as it isn't a faceted field.", field_name))?;
+                faceted_attributes.get(field_name).with_context(|| {
+                    format!("Can't use {:?} as a criterion as it isn't a faceted field.", field_name)
+                })?;
                 match order {
                     "asc" => Ok(Criterion::Asc(field_name.to_string())),
                     "desc" => Ok(Criterion::Desc(field_name.to_string())),

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -81,16 +81,7 @@ impl Index {
         let field_id_docid_facet_values = env.create_database(Some("field-id-docid-facet-values"))?;
         let documents = env.create_database(Some("documents"))?;
 
-        {
-            let mut txn = env.write_txn()?;
-            // The db was just created, we update its metadata with the relevant information.
-            if main.get::<_, Str, SerdeJson<DateTime<Utc>>>(&txn, CREATED_AT_KEY)?.is_none() {
-                let now = Utc::now();
-                main.put::<_, Str, SerdeJson<DateTime<Utc>>>(&mut txn, UPDATED_AT_KEY, &now)?;
-                main.put::<_, Str, SerdeJson<DateTime<Utc>>>(&mut txn, CREATED_AT_KEY, &now)?;
-                txn.commit()?;
-            }
-        }
+        Index::initialize_creation_dates(&env, main)?;
 
         Ok(Index {
             env,

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::mem::take;
 
-use anyhow::{bail, Context as _};
+use anyhow::Context;
 use itertools::Itertools;
 use log::debug;
 use ordered_float::OrderedFloat;
@@ -23,7 +23,6 @@ pub struct AscDesc<'t> {
     rtxn: &'t heed::RoTxn<'t>,
     field_name: String,
     field_id: FieldId,
-    facet_type: FacetType,
     ascending: bool,
     query_tree: Option<Operation>,
     candidates: Box<dyn Iterator<Item = heed::Result<RoaringBitmap>> + 't>,
@@ -51,6 +50,7 @@ impl<'t> AscDesc<'t> {
         Self::new(index, rtxn, parent, field_name, false)
     }
 
+
     fn new(
         index: &'t Index,
         rtxn: &'t heed::RoTxn,
@@ -60,19 +60,19 @@ impl<'t> AscDesc<'t> {
     ) -> anyhow::Result<Self> {
         let fields_ids_map = index.fields_ids_map(rtxn)?;
         let faceted_fields = index.faceted_fields(rtxn)?;
-        let (field_id, facet_type) =
-            field_id_facet_type(&fields_ids_map, &faceted_fields, &field_name)?;
+        let field_id = fields_ids_map
+            .id(&field_name)
+            .with_context(|| format!("field {:?} isn't registered", field_name))?;
 
         Ok(AscDesc {
             index,
             rtxn,
             field_name,
             field_id,
-            facet_type,
             ascending,
             query_tree: None,
             candidates: Box::new(std::iter::empty()),
-            faceted_candidates: index.faceted_documents_ids(rtxn, field_id)?,
+            faceted_candidates: index.number_faceted_documents_ids(rtxn, field_id)?,
             bucket_candidates: RoaringBitmap::new(),
             parent,
         })
@@ -165,27 +165,20 @@ fn facet_ordered<'t>(
     index: &'t Index,
     rtxn: &'t heed::RoTxn,
     field_id: FieldId,
-    facet_type: FacetType,
     ascending: bool,
     candidates: RoaringBitmap,
 ) -> anyhow::Result<Box<dyn Iterator<Item = heed::Result<RoaringBitmap>> + 't>> {
-    match facet_type {
-        FacetType::Number => {
-            if candidates.len() <= CANDIDATES_THRESHOLD {
-                let iter =
-                    iterative_facet_ordered_iter(index, rtxn, field_id, ascending, candidates)?;
-                Ok(Box::new(iter.map(Ok)) as Box<dyn Iterator<Item = _>>)
-            } else {
-                let facet_fn = if ascending {
-                    FacetIter::new_reducing
-                } else {
-                    FacetIter::new_reverse_reducing
-                };
-                let iter = facet_fn(rtxn, index, field_id, candidates)?;
-                Ok(Box::new(iter.map(|res| res.map(|(_, docids)| docids))))
-            }
-        }
-        FacetType::String => bail!("criteria facet type must be a number"),
+    if candidates.len() <= CANDIDATES_THRESHOLD {
+        let iter = iterative_facet_ordered_iter(index, rtxn, field_id, ascending, candidates)?;
+        Ok(Box::new(iter.map(Ok)) as Box<dyn Iterator<Item = _>>)
+    } else {
+        let facet_fn = if ascending {
+            FacetIter::new_reducing
+        } else {
+            FacetIter::new_reverse_reducing
+        };
+        let iter = facet_fn(rtxn, index, field_id, candidates)?;
+        Ok(Box::new(iter.map(|res| res.map(|(_, docids)| docids))))
     }
 }
 

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -50,7 +50,6 @@ impl<'t> AscDesc<'t> {
         Self::new(index, rtxn, parent, field_name, false)
     }
 
-
     fn new(
         index: &'t Index,
         rtxn: &'t heed::RoTxn,
@@ -59,7 +58,6 @@ impl<'t> AscDesc<'t> {
         ascending: bool,
     ) -> anyhow::Result<Self> {
         let fields_ids_map = index.fields_ids_map(rtxn)?;
-        let faceted_fields = index.faceted_fields(rtxn)?;
         let field_id = fields_ids_map
             .id(&field_name)
             .with_context(|| format!("field {:?} isn't registered", field_name))?;

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::mem::take;
 
 use anyhow::Context;
@@ -7,11 +6,10 @@ use log::debug;
 use ordered_float::OrderedFloat;
 use roaring::RoaringBitmap;
 
-use crate::facet::FacetType;
 use crate::search::criteria::{resolve_query_tree, CriteriaBuilder};
 use crate::search::facet::FacetIter;
 use crate::search::query_tree::Operation;
-use crate::{FieldsIdsMap, FieldId, Index};
+use crate::{FieldId, Index};
 use super::{Criterion, CriterionParameters, CriterionResult};
 
 /// Threshold on the number of candidates that will make
@@ -119,7 +117,6 @@ impl<'t> Criterion for AscDesc<'t> {
                                 self.index,
                                 self.rtxn,
                                 self.field_id,
-                                self.facet_type,
                                 self.ascending,
                                 candidates,
                             )?;
@@ -139,20 +136,6 @@ impl<'t> Criterion for AscDesc<'t> {
             }
         }
     }
-}
-
-fn field_id_facet_type(
-    fields_ids_map: &FieldsIdsMap,
-    faceted_fields: &HashMap<String, FacetType>,
-    field: &str,
-) -> anyhow::Result<(FieldId, FacetType)> {
-    let id = fields_ids_map
-        .id(field)
-        .with_context(|| format!("field {:?} isn't registered", field))?;
-    let facet_type = faceted_fields
-        .get(field)
-        .with_context(|| format!("field {:?} isn't faceted", field))?;
-    Ok((id, *facet_type))
 }
 
 /// Returns an iterator over groups of the given candidates in ascending or descending order.

--- a/milli/src/search/distinct/facet_distinct.rs
+++ b/milli/src/search/distinct/facet_distinct.rs
@@ -5,7 +5,7 @@ use roaring::RoaringBitmap;
 
 use super::{Distinct, DocIter};
 use crate::heed_codec::facet::*;
-use crate::{facet::FacetType, DocumentId, FieldId, Index};
+use crate::{DocumentId, FieldId, Index};
 
 const FID_SIZE: usize = size_of::<FieldId>();
 const DOCID_SIZE: usize = size_of::<DocumentId>();
@@ -22,7 +22,6 @@ pub struct FacetDistinct<'a> {
     distinct: FieldId,
     index: &'a Index,
     txn: &'a heed::RoTxn<'a>,
-    facet_type: FacetType,
 }
 
 impl<'a> FacetDistinct<'a> {
@@ -30,14 +29,9 @@ impl<'a> FacetDistinct<'a> {
         distinct: FieldId,
         index: &'a Index,
         txn: &'a heed::RoTxn<'a>,
-        facet_type: FacetType,
-    ) -> Self {
-        Self {
-            distinct,
-            index,
-            txn,
-            facet_type,
-        }
+    ) -> Self
+    {
+        Self { distinct, index, txn }
     }
 }
 
@@ -45,7 +39,6 @@ pub struct FacetDistinctIter<'a> {
     candidates: RoaringBitmap,
     distinct: FieldId,
     excluded: RoaringBitmap,
-    facet_type: FacetType,
     index: &'a Index,
     iter_offset: usize,
     txn: &'a heed::RoTxn<'a>,
@@ -117,6 +110,7 @@ impl<'a> FacetDistinctIter<'a> {
                 // increasing the offset we make sure to get the first valid value for the next
                 // distinct document to keep.
                 self.iter_offset += 1;
+
                 Ok(Some(id))
             }
             // no more candidate at this offset, return.
@@ -188,7 +182,6 @@ impl<'a> Distinct<'_> for FacetDistinct<'a> {
             candidates,
             distinct: self.distinct,
             excluded,
-            facet_type: self.facet_type,
             index: self.index,
             iter_offset: 0,
             txn: self.txn,

--- a/milli/src/search/distinct/facet_distinct.rs
+++ b/milli/src/search/distinct/facet_distinct.rs
@@ -25,13 +25,12 @@ pub struct FacetDistinct<'a> {
 }
 
 impl<'a> FacetDistinct<'a> {
-    pub fn new(
-        distinct: FieldId,
-        index: &'a Index,
-        txn: &'a heed::RoTxn<'a>,
-    ) -> Self
-    {
-        Self { distinct, index, txn }
+    pub fn new(distinct: FieldId, index: &'a Index, txn: &'a heed::RoTxn<'a>) -> Self {
+        Self {
+            distinct,
+            index,
+            txn,
+        }
     }
 }
 
@@ -100,10 +99,9 @@ impl<'a> FacetDistinctIter<'a> {
         let mut candidates_iter = self.candidates.iter().skip(self.iter_offset);
         match candidates_iter.next() {
             Some(id) => {
-                match self.facet_type {
-                    FacetType::String => self.distinct_string(id)?,
-                    FacetType::Number => self.distinct_number(id)?,
-                };
+                // We distinct the document id on its facet strings and facet numbers.
+                self.distinct_string(id)?;
+                self.distinct_number(id)?;
 
                 // The first document of each iteration is kept, since the next call to
                 // `difference_with` will filter out all the documents for that facet value. By

--- a/milli/src/search/distinct/facet_distinct.rs
+++ b/milli/src/search/distinct/facet_distinct.rs
@@ -189,23 +189,21 @@ impl<'a> Distinct<'_> for FacetDistinct<'a> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     use super::super::test::{generate_index, validate_distinct_candidates};
     use super::*;
-    use crate::facet::FacetType;
 
     macro_rules! test_facet_distinct {
-        ($name:ident, $distinct:literal, $facet_type:expr) => {
+        ($name:ident, $distinct:literal) => {
             #[test]
             fn $name() {
                 use std::iter::FromIterator;
 
-                let facets =
-                    HashMap::from_iter(Some(($distinct.to_string(), $facet_type.to_string())));
+                let facets = HashSet::from_iter(Some(($distinct.to_string())));
                 let (index, fid, candidates) = generate_index($distinct, facets);
                 let txn = index.read_txn().unwrap();
-                let mut map_distinct = FacetDistinct::new(fid, &index, &txn, $facet_type);
+                let mut map_distinct = FacetDistinct::new(fid, &index, &txn);
                 let excluded = RoaringBitmap::new();
                 let mut iter = map_distinct.distinct(candidates.clone(), excluded);
                 let count = validate_distinct_candidates(iter.by_ref(), fid, &index);
@@ -215,7 +213,7 @@ mod test {
         };
     }
 
-    test_facet_distinct!(test_string, "txt", FacetType::String);
-    test_facet_distinct!(test_strings, "txts", FacetType::String);
-    test_facet_distinct!(test_number, "cat-int", FacetType::Number);
+    test_facet_distinct!(test_string, "txt");
+    test_facet_distinct!(test_strings, "txts");
+    test_facet_distinct!(test_number, "cat-int");
 }

--- a/milli/src/search/distinct/map_distinct.rs
+++ b/milli/src/search/distinct/map_distinct.rs
@@ -110,7 +110,7 @@ impl<'a, 'b> Distinct<'b> for MapDistinct<'a> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     use super::*;
     use super::super::test::{generate_index, validate_distinct_candidates};
@@ -119,7 +119,7 @@ mod test {
         ($name:ident, $distinct:literal) => {
             #[test]
             fn $name() {
-                let (index, fid, candidates) = generate_index($distinct, HashMap::new());
+                let (index, fid, candidates) = generate_index($distinct, HashSet::new());
                 let txn = index.read_txn().unwrap();
                 let mut map_distinct = MapDistinct::new(fid, &index, &txn);
                 let excluded = RoaringBitmap::new();

--- a/milli/src/search/distinct/mod.rs
+++ b/milli/src/search/distinct/mod.rs
@@ -28,7 +28,7 @@ pub trait Distinct<'a> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashSet;
 
     use once_cell::sync::Lazy;
     use rand::{seq::SliceRandom, Rng};
@@ -74,7 +74,7 @@ mod test {
 
     /// Returns a temporary index populated with random test documents, the FieldId for the
     /// distinct attribute, and the RoaringBitmap with the document ids.
-    pub(crate) fn generate_index(distinct: &str, facets: HashMap<String, String>) -> (TempIndex, FieldId, RoaringBitmap) {
+    pub(crate) fn generate_index(distinct: &str, facets: HashSet<String>) -> (TempIndex, FieldId, RoaringBitmap) {
         let index = TempIndex::new();
         let mut txn = index.write_txn().unwrap();
 

--- a/milli/src/search/facet/facet_condition.rs
+++ b/milli/src/search/facet/facet_condition.rs
@@ -240,9 +240,7 @@ impl FacetCondition {
         let value = items.next().unwrap();
         let (result, svalue) = pest_parse(value);
 
-        // TODO we must normalize instead of lowercase.
         let svalue = svalue.to_lowercase();
-
         Ok(Operator(fid, Equal(result.ok(), svalue)))
     }
 

--- a/milli/src/search/facet/facet_distribution.rs
+++ b/milli/src/search/facet/facet_distribution.rs
@@ -3,12 +3,12 @@ use std::ops::Bound::Unbounded;
 use std::{cmp, fmt};
 
 use anyhow::Context;
-use heed::BytesDecode;
+use heed::{Database, BytesDecode};
+use heed::types::{ByteSlice, Unit};
 use roaring::RoaringBitmap;
 
-use crate::facet::{FacetType, FacetValue};
-use crate::heed_codec::facet::{FacetValueStringCodec, FacetLevelValueF64Codec};
-use crate::heed_codec::facet::{FieldDocIdFacetStringCodec, FieldDocIdFacetF64Codec};
+use crate::facet::FacetType;
+use crate::heed_codec::facet::FacetValueStringCodec;
 use crate::search::facet::{FacetIter, FacetRange};
 use crate::{Index, FieldId, DocumentId};
 
@@ -60,86 +60,81 @@ impl<'a> FacetDistribution<'a> {
 
     /// There is a small amount of candidates OR we ask for facet string values so we
     /// decide to iterate over the facet values of each one of them, one by one.
-    fn facet_values_from_documents(
+    fn facet_distribution_from_documents(
         &self,
         field_id: FieldId,
         facet_type: FacetType,
         candidates: &RoaringBitmap,
-    ) -> heed::Result<BTreeMap<FacetValue, u64>>
+        distribution: &mut BTreeMap<String, u64>,
+    ) -> heed::Result<()>
     {
         fn fetch_facet_values<'t, KC, K: 't>(
-            index: &Index,
             rtxn: &'t heed::RoTxn,
+            db: Database<KC, Unit>,
             field_id: FieldId,
             candidates: &RoaringBitmap,
-        ) -> heed::Result<BTreeMap<FacetValue, u64>>
+            distribution: &mut BTreeMap<String, u64>,
+        ) -> heed::Result<()>
         where
+            K: fmt::Display,
             KC: BytesDecode<'t, DItem = (FieldId, DocumentId, K)>,
-            K: Into<FacetValue>,
         {
-            let mut facet_values = BTreeMap::new();
             let mut key_buffer = vec![field_id];
 
             for docid in candidates.into_iter().take(CANDIDATES_THRESHOLD as usize) {
                 key_buffer.truncate(1);
                 key_buffer.extend_from_slice(&docid.to_be_bytes());
-                let iter = index.field_id_docid_facet_values
+                let iter = db
+                    .remap_key_type::<ByteSlice>()
                     .prefix_iter(rtxn, &key_buffer)?
                     .remap_key_type::<KC>();
 
                 for result in iter {
                     let ((_, _, value), ()) = result?;
-                    *facet_values.entry(value.into()).or_insert(0) += 1;
+                    *distribution.entry(value.to_string()).or_insert(0) += 1;
                 }
             }
 
-            Ok(facet_values)
+            Ok(())
         }
 
-        let index = self.index;
-        let rtxn = self.rtxn;
         match facet_type {
-            FacetType::String => {
-                fetch_facet_values::<FieldDocIdFacetStringCodec, _>(index, rtxn, field_id, candidates)
-            },
             FacetType::Number => {
-                fetch_facet_values::<FieldDocIdFacetF64Codec, _>(index, rtxn, field_id, candidates)
+                let db = self.index.field_id_docid_facet_f64s;
+                fetch_facet_values(self.rtxn, db, field_id, candidates, distribution)
             },
+            FacetType::String => {
+                let db = self.index.field_id_docid_facet_strings;
+                fetch_facet_values(self.rtxn, db, field_id, candidates, distribution)
+            }
         }
     }
 
     /// There is too much documents, we use the facet levels to move throught
     /// the facet values, to find the candidates and values associated.
-    fn facet_values_from_facet_levels(
+    fn facet_numbers_distribution_from_facet_levels(
         &self,
         field_id: FieldId,
-        facet_type: FacetType,
         candidates: &RoaringBitmap,
-    ) -> heed::Result<BTreeMap<FacetValue, u64>>
+        distribution: &mut BTreeMap<String, u64>,
+    ) -> heed::Result<()>
     {
-        let iter = match facet_type {
-            FacetType::String => unreachable!(),
-            FacetType::Number => {
-                let iter = FacetIter::new_non_reducing(
-                    self.rtxn, self.index, field_id, candidates.clone(),
-                )?;
-                iter.map(|r| r.map(|(v, docids)| (FacetValue::from(v), docids)))
-            },
-        };
+        let iter = FacetIter::new_non_reducing(
+            self.rtxn, self.index, field_id, candidates.clone(),
+        )?;
 
-        let mut facet_values = BTreeMap::new();
         for result in iter {
             let (value, mut docids) = result?;
             docids.intersect_with(candidates);
             if !docids.is_empty() {
-                facet_values.insert(value, docids.len());
+                distribution.insert(value.to_string(), docids.len());
             }
-            if facet_values.len() == self.max_values_by_facet {
+            if distribution.len() == self.max_values_by_facet {
                 break;
             }
         }
 
-        Ok(facet_values)
+        Ok(())
     }
 
     /// Placeholder search, a.k.a. no candidates were specified. We iterate throught the
@@ -147,80 +142,73 @@ impl<'a> FacetDistribution<'a> {
     fn facet_values_from_raw_facet_database(
         &self,
         field_id: FieldId,
-        facet_type: FacetType,
-    ) -> heed::Result<BTreeMap<FacetValue, u64>>
+    ) -> heed::Result<BTreeMap<String, u64>>
     {
-        let db = self.index.facet_field_id_value_docids;
-        let level = 0;
-        let iter = match facet_type {
-            FacetType::String => {
-                let iter = db
-                    .prefix_iter(self.rtxn, &[field_id])?
-                    .remap_key_type::<FacetValueStringCodec>()
-                    .map(|r| r.map(|((_, v), docids)| (FacetValue::from(v), docids)));
-                Box::new(iter) as Box::<dyn Iterator<Item=_>>
-            },
-            FacetType::Number => {
-                let db = db.remap_key_type::<FacetLevelValueF64Codec>();
-                let range = FacetRange::new(
-                    self.rtxn, db, field_id, level, Unbounded, Unbounded,
-                )?;
-                Box::new(range.map(|r| r.map(|((_, _, v, _), docids)| (FacetValue::from(v), docids))))
-            },
-        };
+        let mut distribution = BTreeMap::new();
 
-        let mut facet_values = BTreeMap::new();
-        for result in iter {
-            let (value, docids) = result?;
-            facet_values.insert(value, docids.len());
-            if facet_values.len() == self.max_values_by_facet {
+        let db = self.index.facet_id_f64_docids;
+        let range = FacetRange::new(self.rtxn, db, field_id, 0, Unbounded, Unbounded)?;
+
+        for result in range {
+            let ((_, _, value, _), docids) = result?;
+            distribution.insert(value.to_string(), docids.len());
+            if distribution.len() == self.max_values_by_facet {
                 break;
             }
         }
 
-        Ok(facet_values)
+        let iter = self.index
+            .facet_id_string_docids
+            .remap_key_type::<ByteSlice>()
+            .prefix_iter(self.rtxn, &[field_id])?
+            .remap_key_type::<FacetValueStringCodec>();
+
+        for result in iter {
+            let ((_, value), docids) = result?;
+            distribution.insert(value.to_string(), docids.len());
+            if distribution.len() == self.max_values_by_facet {
+                break;
+            }
+        }
+
+        Ok(distribution)
     }
 
-    fn facet_values(
-        &self,
-        field_id: FieldId,
-        facet_type: FacetType,
-    ) -> heed::Result<BTreeMap<FacetValue, u64>>
-    {
+    fn facet_values(&self, field_id: FieldId) -> heed::Result<BTreeMap<String, u64>> {
+        use FacetType::{Number, String};
+
         if let Some(candidates) = self.candidates.as_ref() {
             // Classic search, candidates were specified, we must return facet values only related
             // to those candidates. We also enter here for facet strings for performance reasons.
-            if candidates.len() <= CANDIDATES_THRESHOLD || facet_type == FacetType::String {
-                self.facet_values_from_documents(field_id, facet_type, candidates)
+            let mut distribution = BTreeMap::new();
+            if candidates.len() <= CANDIDATES_THRESHOLD {
+                self.facet_distribution_from_documents(field_id, Number, candidates, &mut distribution)?;
+                self.facet_distribution_from_documents(field_id, String, candidates, &mut distribution)?;
             } else {
-                self.facet_values_from_facet_levels(field_id, facet_type, candidates)
+                self.facet_numbers_distribution_from_facet_levels(field_id, candidates, &mut distribution)?;
+                self.facet_distribution_from_documents(field_id, String, candidates, &mut distribution)?;
             }
+
+            Ok(distribution)
         } else {
-            self.facet_values_from_raw_facet_database(field_id, facet_type)
+            self.facet_values_from_raw_facet_database(field_id)
         }
     }
 
-    pub fn execute(&self) -> anyhow::Result<BTreeMap<String, BTreeMap<FacetValue, u64>>> {
+    pub fn execute(&self) -> anyhow::Result<BTreeMap<String, BTreeMap<String, u64>>> {
         let fields_ids_map = self.index.fields_ids_map(self.rtxn)?;
         let faceted_fields = self.index.faceted_fields(self.rtxn)?;
-        let fields_ids: Vec<_> = match &self.facets {
-            Some(names) => names
-                .iter()
-                .filter_map(|n| faceted_fields.get(n).map(|t| (n.to_string(), *t)))
-                .collect(),
-            None => faceted_fields.into_iter().collect(),
-        };
 
-        let mut facets_values = BTreeMap::new();
-        for (name, ftype) in fields_ids {
+        let mut distribution = BTreeMap::new();
+        for name in faceted_fields {
             let fid = fields_ids_map.id(&name).with_context(|| {
                 format!("missing field name {:?} from the fields id map", name)
             })?;
-            let values = self.facet_values(fid, ftype)?;
-            facets_values.insert(name, values);
+            let values = self.facet_values(fid)?;
+            distribution.insert(name, values);
         }
 
-        Ok(facets_values)
+        Ok(distribution)
     }
 }
 

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -140,7 +140,7 @@ impl<'t> FacetIter<'t> {
         documents_ids: RoaringBitmap,
     ) -> heed::Result<FacetIter<'t>>
     {
-        let db = index.facet_field_id_value_docids.remap_key_type::<FacetLevelValueF64Codec>();
+        let db = index.facet_id_f64_docids.remap_key_type::<FacetLevelValueF64Codec>();
         let highest_level = Self::highest_level(rtxn, db, field_id)?.unwrap_or(0);
         let highest_iter = FacetRange::new(rtxn, db, field_id, highest_level, Unbounded, Unbounded)?;
         let level_iters = vec![(documents_ids, Left(highest_iter))];
@@ -157,7 +157,7 @@ impl<'t> FacetIter<'t> {
         documents_ids: RoaringBitmap,
     ) -> heed::Result<FacetIter<'t>>
     {
-        let db = index.facet_field_id_value_docids.remap_key_type::<FacetLevelValueF64Codec>();
+        let db = index.facet_id_f64_docids.remap_key_type::<FacetLevelValueF64Codec>();
         let highest_level = Self::highest_level(rtxn, db, field_id)?.unwrap_or(0);
         let highest_iter = FacetRevRange::new(rtxn, db, field_id, highest_level, Unbounded, Unbounded)?;
         let level_iters = vec![(documents_ids, Right(highest_iter))];
@@ -175,7 +175,7 @@ impl<'t> FacetIter<'t> {
         documents_ids: RoaringBitmap,
     ) -> heed::Result<FacetIter<'t>>
     {
-        let db = index.facet_field_id_value_docids.remap_key_type::<FacetLevelValueF64Codec>();
+        let db = index.facet_id_f64_docids.remap_key_type::<FacetLevelValueF64Codec>();
         let highest_level = Self::highest_level(rtxn, db, field_id)?.unwrap_or(0);
         let highest_iter = FacetRange::new(rtxn, db, field_id, highest_level, Unbounded, Unbounded)?;
         let level_iters = vec![(documents_ids, Left(highest_iter))];

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -9,7 +9,7 @@ use crate::heed_codec::CboRoaringBitmapCodec;
 use crate::heed_codec::facet::FacetLevelValueF64Codec;
 use crate::{Index, FieldId};
 
-pub use self::facet_condition::{FacetCondition, FacetNumberOperator, FacetStringOperator};
+pub use self::facet_condition::{FacetCondition, Operator};
 pub use self::facet_distribution::FacetDistribution;
 
 mod facet_condition;

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -145,7 +145,7 @@ impl<'a> Search<'a> {
                 let faceted_fields = self.index.faceted_fields(self.rtxn)?;
                 match faceted_fields.get(name) {
                     Some(facet_type) => {
-                        let distinct = FacetDistinct::new(id, self.index, self.rtxn, *facet_type);
+                        let distinct = FacetDistinct::new(id, self.index, self.rtxn);
                         self.perform_sort(distinct, matching_words, criteria)
                     }
                     None => {

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -141,15 +141,12 @@ impl<'a> Search<'a> {
                 let field_ids_map = self.index.fields_ids_map(self.rtxn)?;
                 let id = field_ids_map.id(name).expect("distinct not present in field map");
                 let faceted_fields = self.index.faceted_fields(self.rtxn)?;
-                match faceted_fields.get(name) {
-                    Some(facet_type) => {
-                        let distinct = FacetDistinct::new(id, self.index, self.rtxn);
-                        self.perform_sort(distinct, matching_words, criteria)
-                    }
-                    None => {
-                        let distinct = MapDistinct::new(id, self.index, self.rtxn);
-                        self.perform_sort(distinct, matching_words, criteria)
-                    }
+                if faceted_fields.contains(name) {
+                    let distinct = FacetDistinct::new(id, self.index, self.rtxn);
+                    self.perform_sort(distinct, matching_words, criteria)
+                } else {
+                    let distinct = MapDistinct::new(id, self.index, self.rtxn);
+                    self.perform_sort(distinct, matching_words, criteria)
                 }
             }
         }

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -16,9 +16,7 @@ use distinct::{Distinct, DocIter, FacetDistinct, MapDistinct, NoopDistinct};
 use crate::search::criteria::r#final::{Final, FinalResult};
 use crate::{Index, DocumentId};
 
-pub use self::facet::{
-    FacetCondition, FacetDistribution, FacetIter, FacetNumberOperator, FacetStringOperator,
-};
+pub use self::facet::{FacetCondition, FacetDistribution, FacetIter, Operator};
 pub use self::query_tree::MatchingWords;
 use self::query_tree::QueryTreeBuilder;
 

--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -49,8 +49,10 @@ impl<'t, 'u, 'i> ClearDocuments<'t, 'u, 'i> {
         self.index.put_fields_distribution(self.wtxn, &FieldsDistribution::default())?;
 
         // We clean all the faceted documents ids.
-        for (field_id, _) in faceted_fields {
-            self.index.put_faceted_documents_ids(self.wtxn, field_id, &RoaringBitmap::default())?;
+        let empty = RoaringBitmap::default();
+        for field_id in faceted_fields {
+            self.index.put_number_faceted_documents_ids(self.wtxn, field_id, &empty)?;
+            self.index.put_string_faceted_documents_ids(self.wtxn, field_id, &empty)?;
         }
 
         // Clear the other databases.

--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -30,8 +30,10 @@ impl<'t, 'u, 'i> ClearDocuments<'t, 'u, 'i> {
             word_prefix_pair_proximity_docids,
             word_level_position_docids,
             word_prefix_level_position_docids,
-            facet_field_id_value_docids,
-            field_id_docid_facet_values,
+            facet_id_f64_docids,
+            facet_id_string_docids,
+            field_id_docid_facet_f64s,
+            field_id_docid_facet_strings,
             documents,
         } = self.index;
 
@@ -59,8 +61,10 @@ impl<'t, 'u, 'i> ClearDocuments<'t, 'u, 'i> {
         word_prefix_pair_proximity_docids.clear(self.wtxn)?;
         word_level_position_docids.clear(self.wtxn)?;
         word_prefix_level_position_docids.clear(self.wtxn)?;
-        facet_field_id_value_docids.clear(self.wtxn)?;
-        field_id_docid_facet_values.clear(self.wtxn)?;
+        facet_id_f64_docids.clear(self.wtxn)?;
+        facet_id_string_docids.clear(self.wtxn)?;
+        field_id_docid_facet_f64s.clear(self.wtxn)?;
+        field_id_docid_facet_strings.clear(self.wtxn)?;
         documents.clear(self.wtxn)?;
 
         Ok(number_of_documents)

--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -118,8 +118,10 @@ mod tests {
         assert!(index.docid_word_positions.is_empty(&rtxn).unwrap());
         assert!(index.word_pair_proximity_docids.is_empty(&rtxn).unwrap());
         assert!(index.word_prefix_pair_proximity_docids.is_empty(&rtxn).unwrap());
-        assert!(index.facet_field_id_value_docids.is_empty(&rtxn).unwrap());
-        assert!(index.field_id_docid_facet_values.is_empty(&rtxn).unwrap());
+        assert!(index.facet_id_f64_docids.is_empty(&rtxn).unwrap());
+        assert!(index.facet_id_string_docids.is_empty(&rtxn).unwrap());
+        assert!(index.field_id_docid_facet_f64s.is_empty(&rtxn).unwrap());
+        assert!(index.field_id_docid_facet_strings.is_empty(&rtxn).unwrap());
         assert!(index.documents.is_empty(&rtxn).unwrap());
     }
 }

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -330,11 +330,11 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
         )?;
 
         // Remove the documents ids from the faceted documents ids.
-        let faceted_fields = self.index.faceted_fields_ids(self.wtxn)?;
-        for (field_id, facet_type) in faceted_fields {
-            let mut docids = self.index.faceted_documents_ids(self.wtxn, field_id)?;
+        for field_id in self.index.faceted_fields_ids(self.wtxn)? {
+            // Remove docids from the number faceted documents ids
+            let mut docids = self.index.number_faceted_documents_ids(self.wtxn, field_id)?;
             docids.difference_with(&self.documents_ids);
-            self.index.put_faceted_documents_ids(self.wtxn, field_id, &docids)?;
+            self.index.put_number_faceted_documents_ids(self.wtxn, field_id, &docids)?;
 
             remove_docids_from_field_id_docid_facet_value(
                 self.wtxn,
@@ -343,6 +343,11 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
                 &self.documents_ids,
                 |(_fid, docid, _value)| docid,
             )?;
+
+            // Remove docids from the string faceted documents ids
+            let mut docids = self.index.string_faceted_documents_ids(self.wtxn, field_id)?;
+            docids.difference_with(&self.documents_ids);
+            self.index.put_string_faceted_documents_ids(self.wtxn, field_id, &docids)?;
 
             remove_docids_from_field_id_docid_facet_value(
                 self.wtxn,

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -98,7 +98,6 @@ impl<'t, 'u, 'i> Facets<'t, 'u, 'i> {
             self.index.put_string_faceted_documents_ids(self.wtxn, field_id, &string_documents_ids)?;
             self.index.put_number_faceted_documents_ids(self.wtxn, field_id, &number_documents_ids)?;
 
-            // Store the
             write_into_lmdb_database(
                 self.wtxn,
                 *self.index.facet_id_f64_docids.as_polymorph(),

--- a/milli/src/update/index_documents/store.rs
+++ b/milli/src/update/index_documents/store.rs
@@ -816,7 +816,6 @@ fn extract_facet_values(value: &Value) -> (Vec<f64>, Vec<String>) {
                 output_numbers.push(float);
             },
             Value::String(string) => {
-                // TODO must be normalized and not only lowercased.
                 let string = string.trim().to_lowercase();
                 output_strings.push(string);
             },

--- a/milli/src/update/index_documents/store.rs
+++ b/milli/src/update/index_documents/store.rs
@@ -6,25 +6,24 @@ use std::iter::FromIterator;
 use std::time::Instant;
 use std::{cmp, iter};
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use bstr::ByteSlice as _;
 use fst::Set;
 use grenad::{Reader, FileFuse, Writer, Sorter, CompressionType};
 use heed::BytesEncode;
 use linked_hash_map::LinkedHashMap;
-use log::{debug, info, warn};
+use log::{debug, info};
 use meilisearch_tokenizer::{Analyzer, AnalyzerConfig, Token, TokenKind, token::SeparatorKind};
 use ordered_float::OrderedFloat;
 use roaring::RoaringBitmap;
 use serde_json::Value;
 use tempfile::tempfile;
 
-use crate::facet::{FacetType, FacetValue};
 use crate::heed_codec::facet::{FacetValueStringCodec, FacetLevelValueF64Codec};
 use crate::heed_codec::facet::{FieldDocIdFacetStringCodec, FieldDocIdFacetF64Codec};
 use crate::heed_codec::{BoRoaringBitmapCodec, CboRoaringBitmapCodec};
 use crate::update::UpdateIndexingStep;
-use crate::{json_to_string, SmallVec8, SmallVec32, Position, DocumentId, FieldId, FieldsIdsMap};
+use crate::{json_to_string, SmallVec32, Position, DocumentId, FieldId, FieldsIdsMap};
 
 use super::{MergeFn, create_writer, create_sorter, writer_into_reader};
 use super::merge_function::{
@@ -45,8 +44,10 @@ pub struct Readers {
     pub docid_word_positions: Reader<FileFuse>,
     pub words_pairs_proximities_docids: Reader<FileFuse>,
     pub word_level_position_docids: Reader<FileFuse>,
-    pub facet_field_value_docids: Reader<FileFuse>,
-    pub field_id_docid_facet_values: Reader<FileFuse>,
+    pub facet_field_numbers_docids: Reader<FileFuse>,
+    pub facet_field_strings_docids: Reader<FileFuse>,
+    pub field_id_docid_facet_numbers: Reader<FileFuse>,
+    pub field_id_docid_facet_strings: Reader<FileFuse>,
     pub documents: Reader<FileFuse>,
 }
 
@@ -55,13 +56,14 @@ pub struct Store<'s, A> {
     primary_key: String,
     fields_ids_map: FieldsIdsMap,
     searchable_fields: HashSet<FieldId>,
-    faceted_fields: HashMap<FieldId, FacetType>,
+    faceted_fields: HashSet<FieldId>,
     // Caches
     word_docids: LinkedHashMap<SmallVec32<u8>, RoaringBitmap>,
     word_docids_limit: usize,
     words_pairs_proximities_docids: LinkedHashMap<(SmallVec32<u8>, SmallVec32<u8>, u8), RoaringBitmap>,
     words_pairs_proximities_docids_limit: usize,
-    facet_field_value_docids: LinkedHashMap<(u8, FacetValue), RoaringBitmap>,
+    facet_field_number_docids: LinkedHashMap<(FieldId, OrderedFloat<f64>), RoaringBitmap>,
+    facet_field_string_docids: LinkedHashMap<(FieldId, String), RoaringBitmap>,
     facet_field_value_docids_limit: usize,
     // MTBL parameters
     chunk_compression_type: CompressionType,
@@ -72,8 +74,10 @@ pub struct Store<'s, A> {
     word_docids_sorter: Sorter<MergeFn>,
     words_pairs_proximities_docids_sorter: Sorter<MergeFn>,
     word_level_position_docids_sorter: Sorter<MergeFn>,
-    facet_field_value_docids_sorter: Sorter<MergeFn>,
-    field_id_docid_facet_values_sorter: Sorter<MergeFn>,
+    facet_field_numbers_docids_sorter: Sorter<MergeFn>,
+    facet_field_strings_docids_sorter: Sorter<MergeFn>,
+    field_id_docid_facet_numbers_sorter: Sorter<MergeFn>,
+    field_id_docid_facet_strings_sorter: Sorter<MergeFn>,
     // MTBL writers
     docid_word_positions_writer: Writer<File>,
     documents_writer: Writer<File>,
@@ -86,7 +90,7 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
         primary_key: String,
         fields_ids_map: FieldsIdsMap,
         searchable_fields: HashSet<FieldId>,
-        faceted_fields: HashMap<FieldId, FacetType>,
+        faceted_fields: HashSet<FieldId>,
         linked_hash_map_size: Option<usize>,
         max_nb_chunks: Option<usize>,
         max_memory: Option<usize>,
@@ -132,7 +136,7 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
             max_nb_chunks,
             max_memory,
         );
-        let facet_field_value_docids_sorter = create_sorter(
+        let facet_field_numbers_docids_sorter = create_sorter(
             facet_field_value_docids_merge,
             chunk_compression_type,
             chunk_compression_level,
@@ -140,7 +144,23 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
             max_nb_chunks,
             max_memory,
         );
-        let field_id_docid_facet_values_sorter = create_sorter(
+        let facet_field_strings_docids_sorter = create_sorter(
+            facet_field_value_docids_merge,
+            chunk_compression_type,
+            chunk_compression_level,
+            chunk_fusing_shrink_size,
+            max_nb_chunks,
+            max_memory,
+        );
+        let field_id_docid_facet_numbers_sorter = create_sorter(
+            field_id_docid_facet_values_merge,
+            chunk_compression_type,
+            chunk_compression_level,
+            chunk_fusing_shrink_size,
+            max_nb_chunks,
+            Some(1024 * 1024 * 1024), // 1MB
+        );
+        let field_id_docid_facet_strings_sorter = create_sorter(
             field_id_docid_facet_values_merge,
             chunk_compression_type,
             chunk_compression_level,
@@ -173,7 +193,8 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
             word_docids_limit: linked_hash_map_size,
             words_pairs_proximities_docids: LinkedHashMap::with_capacity(linked_hash_map_size),
             words_pairs_proximities_docids_limit: linked_hash_map_size,
-            facet_field_value_docids: LinkedHashMap::with_capacity(linked_hash_map_size),
+            facet_field_number_docids: LinkedHashMap::with_capacity(linked_hash_map_size),
+            facet_field_string_docids: LinkedHashMap::with_capacity(linked_hash_map_size),
             facet_field_value_docids_limit: linked_hash_map_size,
             // MTBL parameters
             chunk_compression_type,
@@ -184,8 +205,10 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
             word_docids_sorter,
             words_pairs_proximities_docids_sorter,
             word_level_position_docids_sorter,
-            facet_field_value_docids_sorter,
-            field_id_docid_facet_values_sorter,
+            facet_field_numbers_docids_sorter,
+            facet_field_strings_docids_sorter,
+            field_id_docid_facet_numbers_sorter,
+            field_id_docid_facet_strings_sorter,
             // MTBL writers
             docid_word_positions_writer,
             documents_writer,
@@ -215,34 +238,68 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
         Ok(())
     }
 
-    // Save the documents ids under the facet field id and value we have seen it.
-    fn insert_facet_values_docid(
+    fn insert_facet_number_values_docid(
         &mut self,
         field_id: FieldId,
-        field_value: FacetValue,
+        value: OrderedFloat<f64>,
         id: DocumentId,
     ) -> anyhow::Result<()>
     {
-        Self::write_field_id_docid_facet_value(&mut self.field_id_docid_facet_values_sorter, field_id, id, &field_value)?;
+        let sorter = &mut self.field_id_docid_facet_numbers_sorter;
+        Self::write_field_id_docid_facet_number_value(sorter, field_id, id, value)?;
 
-        let key = (field_id, field_value);
+        let key = (field_id, value);
         // if get_refresh finds the element it is assured to be at the end of the linked hash map.
-        match self.facet_field_value_docids.get_refresh(&key) {
+        match self.facet_field_number_docids.get_refresh(&key) {
             Some(old) => { old.insert(id); },
             None => {
                 // A newly inserted element is append at the end of the linked hash map.
-                self.facet_field_value_docids.insert(key, RoaringBitmap::from_iter(Some(id)));
+                self.facet_field_number_docids.insert(key, RoaringBitmap::from_iter(Some(id)));
                 // If the word docids just reached it's capacity we must make sure to remove
                 // one element, this way next time we insert we doesn't grow the capacity.
-                if self.facet_field_value_docids.len() == self.facet_field_value_docids_limit {
+                if self.facet_field_number_docids.len() == self.facet_field_value_docids_limit {
                     // Removing the front element is equivalent to removing the LRU element.
-                    Self::write_facet_field_value_docids(
-                        &mut self.facet_field_value_docids_sorter,
-                        self.facet_field_value_docids.pop_front(),
+                    Self::write_facet_field_number_docids(
+                        &mut self.facet_field_numbers_docids_sorter,
+                        self.facet_field_number_docids.pop_front(),
                     )?;
                 }
             }
         }
+
+        Ok(())
+    }
+
+    // Save the documents ids under the facet field id and value we have seen it.
+    fn insert_facet_string_values_docid(
+        &mut self,
+        field_id: FieldId,
+        value: String,
+        id: DocumentId,
+    ) -> anyhow::Result<()>
+    {
+        let sorter = &mut self.field_id_docid_facet_strings_sorter;
+        Self::write_field_id_docid_facet_string_value(sorter, field_id, id, &value)?;
+
+        let key = (field_id, value);
+        // if get_refresh finds the element it is assured to be at the end of the linked hash map.
+        match self.facet_field_string_docids.get_refresh(&key) {
+            Some(old) => { old.insert(id); },
+            None => {
+                // A newly inserted element is append at the end of the linked hash map.
+                self.facet_field_string_docids.insert(key, RoaringBitmap::from_iter(Some(id)));
+                // If the word docids just reached it's capacity we must make sure to remove
+                // one element, this way next time we insert we doesn't grow the capacity.
+                if self.facet_field_string_docids.len() == self.facet_field_value_docids_limit {
+                    // Removing the front element is equivalent to removing the LRU element.
+                    Self::write_facet_field_string_docids(
+                        &mut self.facet_field_strings_docids_sorter,
+                        self.facet_field_string_docids.pop_front(),
+                    )?;
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -287,7 +344,8 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
         &mut self,
         document_id: DocumentId,
         words_positions: &mut HashMap<String, SmallVec32<Position>>,
-        facet_values: &mut HashMap<FieldId, SmallVec8<FacetValue>>,
+        facet_numbers_values: &mut HashMap<FieldId, Vec<f64>>,
+        facet_strings_values: &mut HashMap<FieldId, Vec<String>>,
         record: &[u8],
     ) -> anyhow::Result<()>
     {
@@ -306,10 +364,18 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
 
         words_positions.clear();
 
-        // We store document_id associated with all the field id and values.
-        for (field, values) in facet_values.drain() {
+        // We store document_id associated with all the facet numbers fields ids and values.
+        for (field, values) in facet_numbers_values.drain() {
             for value in values {
-                self.insert_facet_values_docid(field, value, document_id)?;
+                let value = OrderedFloat::from(value);
+                self.insert_facet_number_values_docid(field, value, document_id)?;
+            }
+        }
+
+        // We store document_id associated with all the facet strings fields ids and values.
+        for (field, values) in facet_strings_values.drain() {
+            for value in values {
+                self.insert_facet_string_values_docid(field, value, document_id)?;
             }
         }
 
@@ -409,20 +475,16 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
         Ok(())
     }
 
-    fn write_facet_field_value_docids<I>(
+    fn write_facet_field_string_docids<I>(
         sorter: &mut Sorter<MergeFn>,
         iter: I,
     ) -> anyhow::Result<()>
-    where I: IntoIterator<Item=((FieldId, FacetValue), RoaringBitmap)>
+    where I: IntoIterator<Item=((FieldId, String), RoaringBitmap)>
     {
-        use FacetValue::*;
-
         for ((field_id, value), docids) in iter {
-            let result = match value {
-                String(s) => FacetValueStringCodec::bytes_encode(&(field_id, &s)).map(Cow::into_owned),
-                Number(f) => FacetLevelValueF64Codec::bytes_encode(&(field_id, 0, *f, *f)).map(Cow::into_owned),
-            };
-            let key = result.context("could not serialize facet key")?;
+            let key = FacetValueStringCodec::bytes_encode(&(field_id, &value))
+                .map(Cow::into_owned)
+                .context("could not serialize facet key")?;
             let bytes = CboRoaringBitmapCodec::bytes_encode(&docids)
                 .context("could not serialize docids")?;
             if lmdb_key_valid_size(&key) {
@@ -433,21 +495,55 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
         Ok(())
     }
 
-    fn write_field_id_docid_facet_value(
+    fn write_facet_field_number_docids<I>(
+        sorter: &mut Sorter<MergeFn>,
+        iter: I,
+    ) -> anyhow::Result<()>
+    where I: IntoIterator<Item=((FieldId, OrderedFloat<f64>), RoaringBitmap)>
+    {
+        for ((field_id, value), docids) in iter {
+            let key = FacetLevelValueF64Codec::bytes_encode(&(field_id, 0, *value, *value))
+                .map(Cow::into_owned)
+                .context("could not serialize facet key")?;
+            let bytes = CboRoaringBitmapCodec::bytes_encode(&docids)
+                .context("could not serialize docids")?;
+            if lmdb_key_valid_size(&key) {
+                sorter.insert(&key, &bytes)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write_field_id_docid_facet_number_value(
         sorter: &mut Sorter<MergeFn>,
         field_id: FieldId,
         document_id: DocumentId,
-        value: &FacetValue,
+        value: OrderedFloat<f64>,
     ) -> anyhow::Result<()>
     {
-        use FacetValue::*;
+        let key = FieldDocIdFacetF64Codec::bytes_encode(&(field_id, document_id, *value))
+            .map(Cow::into_owned)
+            .context("could not serialize facet key")?;
 
-        let result = match value {
-            String(s) => FieldDocIdFacetStringCodec::bytes_encode(&(field_id, document_id, s)).map(Cow::into_owned),
-            Number(f) => FieldDocIdFacetF64Codec::bytes_encode(&(field_id, document_id, **f)).map(Cow::into_owned),
-        };
+        if lmdb_key_valid_size(&key) {
+            sorter.insert(&key, &[])?;
+        }
 
-        let key = result.context("could not serialize facet key")?;
+        Ok(())
+    }
+
+    fn write_field_id_docid_facet_string_value(
+        sorter: &mut Sorter<MergeFn>,
+        field_id: FieldId,
+        document_id: DocumentId,
+        value: &str,
+    ) -> anyhow::Result<()>
+    {
+        let key = FieldDocIdFacetStringCodec::bytes_encode(&(field_id, document_id, value))
+            .map(Cow::into_owned)
+            .context("could not serialize facet key")?;
+
         if lmdb_key_valid_size(&key) {
             sorter.insert(&key, &[])?;
         }
@@ -493,7 +589,8 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
 
         let mut before = Instant::now();
         let mut words_positions = HashMap::new();
-        let mut facet_values = HashMap::new();
+        let mut facet_numbers_values = HashMap::new();
+        let mut facet_strings_values = HashMap::new();
 
         let mut count: usize = 0;
         while let Some((key, value)) = documents.next()? {
@@ -513,32 +610,12 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
                 }
 
                 for (attr, content) in document.iter() {
-                    if self.faceted_fields.contains_key(&attr) || self.searchable_fields.contains(&attr) {
+                    if self.faceted_fields.contains(&attr) || self.searchable_fields.contains(&attr) {
                         let value = serde_json::from_slice(content)?;
 
-                        if let Some(ftype) = self.faceted_fields.get(&attr) {
-                            let mut values = match parse_facet_value(*ftype, &value) {
-                                Ok(values) => values,
-                                Err(e) => {
-                                    // We extract the name of the attribute and the document id
-                                    // to help users debug a facet type conversion.
-                                    let attr_name = self.fields_ids_map.name(attr).unwrap();
-                                    let document_id: Value = self.fields_ids_map.id(&self.primary_key)
-                                        .and_then(|fid| document.get(fid))
-                                        .map(serde_json::from_slice)
-                                        .unwrap()?;
-
-                                    let context = format!(
-                                        "while extracting facet from the {:?} attribute in the {} document",
-                                        attr_name, document_id,
-                                    );
-                                    warn!("{}", e.context(context));
-
-                                    SmallVec8::default()
-                                },
-                            };
-                            facet_values.entry(attr).or_insert_with(SmallVec8::new).extend(values.drain(..));
-                        }
+                        let (facet_numbers, facet_strings) = extract_facet_values(&value);
+                        facet_numbers_values.entry(attr).or_insert_with(Vec::new).extend(facet_numbers);
+                        facet_strings_values.entry(attr).or_insert_with(Vec::new).extend(facet_strings);
 
                         if self.searchable_fields.contains(&attr) {
                             let content = match json_to_string(&value) {
@@ -558,7 +635,13 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
                 }
 
                 // We write the document in the documents store.
-                self.write_document(document_id, &mut words_positions, &mut facet_values, value)?;
+                self.write_document(
+                    document_id,
+                    &mut words_positions,
+                    &mut facet_numbers_values,
+                    &mut facet_strings_values,
+                    value,
+                )?;
             }
 
             // Compute the document id of the next document.
@@ -585,9 +668,14 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
             &mut self.words_pairs_proximities_docids_sorter,
             self.words_pairs_proximities_docids,
         )?;
-        Self::write_facet_field_value_docids(
-            &mut self.facet_field_value_docids_sorter,
-            self.facet_field_value_docids,
+        Self::write_facet_field_number_docids(
+            &mut self.facet_field_numbers_docids_sorter,
+            self.facet_field_number_docids,
+        )?;
+
+        Self::write_facet_field_string_docids(
+            &mut self.facet_field_strings_docids_sorter,
+            self.facet_field_string_docids,
         )?;
 
         let mut word_docids_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
@@ -613,18 +701,26 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
         let mut word_level_position_docids_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
         self.word_level_position_docids_sorter.write_into(&mut word_level_position_docids_wtr)?;
 
-        let mut facet_field_value_docids_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
-        self.facet_field_value_docids_sorter.write_into(&mut facet_field_value_docids_wtr)?;
+        let mut facet_field_numbers_docids_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
+        self.facet_field_numbers_docids_sorter.write_into(&mut facet_field_numbers_docids_wtr)?;
 
-        let mut field_id_docid_facet_values_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
-        self.field_id_docid_facet_values_sorter.write_into(&mut field_id_docid_facet_values_wtr)?;
+        let mut facet_field_strings_docids_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
+        self.facet_field_strings_docids_sorter.write_into(&mut facet_field_strings_docids_wtr)?;
+
+        let mut field_id_docid_facet_numbers_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
+        self.field_id_docid_facet_numbers_sorter.write_into(&mut field_id_docid_facet_numbers_wtr)?;
+
+        let mut field_id_docid_facet_strings_wtr = tempfile().and_then(|f| create_writer(comp_type, comp_level, f))?;
+        self.field_id_docid_facet_strings_sorter.write_into(&mut field_id_docid_facet_strings_wtr)?;
 
         let main = writer_into_reader(main_wtr, shrink_size)?;
         let word_docids = writer_into_reader(word_docids_wtr, shrink_size)?;
         let words_pairs_proximities_docids = writer_into_reader(words_pairs_proximities_docids_wtr, shrink_size)?;
         let word_level_position_docids = writer_into_reader(word_level_position_docids_wtr, shrink_size)?;
-        let facet_field_value_docids = writer_into_reader(facet_field_value_docids_wtr, shrink_size)?;
-        let field_id_docid_facet_values = writer_into_reader(field_id_docid_facet_values_wtr, shrink_size)?;
+        let facet_field_numbers_docids = writer_into_reader(facet_field_numbers_docids_wtr, shrink_size)?;
+        let facet_field_strings_docids = writer_into_reader(facet_field_strings_docids_wtr, shrink_size)?;
+        let field_id_docid_facet_numbers = writer_into_reader(field_id_docid_facet_numbers_wtr, shrink_size)?;
+        let field_id_docid_facet_strings = writer_into_reader(field_id_docid_facet_strings_wtr, shrink_size)?;
         let docid_word_positions = writer_into_reader(self.docid_word_positions_writer, shrink_size)?;
         let documents = writer_into_reader(self.documents_writer, shrink_size)?;
 
@@ -634,8 +730,10 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
             docid_word_positions,
             words_pairs_proximities_docids,
             word_level_position_docids,
-            facet_field_value_docids,
-            field_id_docid_facet_values,
+            facet_field_numbers_docids,
+            facet_field_strings_docids,
+            field_id_docid_facet_numbers,
+            field_id_docid_facet_strings,
             documents,
         })
     }
@@ -710,71 +808,36 @@ fn process_tokens<'a>(tokens: impl Iterator<Item = Token<'a>>) -> impl Iterator<
     .filter(|(_, t)| t.is_word())
 }
 
-fn parse_facet_value(ftype: FacetType, value: &Value) -> anyhow::Result<SmallVec8<FacetValue>> {
-    use FacetValue::*;
-
-    fn inner_parse_facet_value(
-        ftype: FacetType,
+fn extract_facet_values(value: &Value) -> (Vec<f64>, Vec<String>) {
+    fn inner_extract_facet_values(
         value: &Value,
         can_recurse: bool,
-        output: &mut SmallVec8<FacetValue>,
-    ) -> anyhow::Result<()>
-    {
+        output_numbers: &mut Vec<f64>,
+        output_strings: &mut Vec<String>,
+    ) {
         match value {
-            Value::Null => Ok(()),
-            Value::Bool(b) => match ftype {
-                FacetType::String => {
-                    output.push(String(b.to_string()));
-                    Ok(())
-                },
-                FacetType::Number => {
-                    output.push(Number(OrderedFloat(if *b { 1.0 } else { 0.0 })));
-                    Ok(())
-                },
-            },
-            Value::Number(number) => match ftype {
-                FacetType::String => {
-                    output.push(String(number.to_string()));
-                    Ok(())
-                },
-                FacetType::Number => match number.as_f64() {
-                    Some(float) => {
-                        output.push(Number(OrderedFloat(float)));
-                        Ok(())
-                    },
-                    None => bail!("invalid facet type, expecting {} found number", ftype),
-                },
+            Value::Null => (),
+            Value::Bool(b) => output_strings.push(b.to_string()),
+            Value::Number(number) => if let Some(float) = number.as_f64() {
+                output_numbers.push(float);
             },
             Value::String(string) => {
                 // TODO must be normalized and not only lowercased.
                 let string = string.trim().to_lowercase();
-                match ftype {
-                    FacetType::String => {
-                        output.push(String(string));
-                        Ok(())
-                    },
-                    FacetType::Number => match string.parse() {
-                        Ok(float) => {
-                            output.push(Number(OrderedFloat(float)));
-                            Ok(())
-                        },
-                        Err(_err) => bail!("invalid facet type, expecting {} found string", ftype),
-                    },
-                }
+                output_strings.push(string);
             },
             Value::Array(values) => if can_recurse {
-                values.iter().map(|v| inner_parse_facet_value(ftype, v, false, output)).collect()
-            } else {
-                bail!(
-                    "invalid facet type, expecting {} found array (recursive arrays are not supported)",
-                    ftype,
-                );
+                for value in values {
+                    inner_extract_facet_values(value, false, output_numbers, output_strings);
+                }
             },
-            Value::Object(_) => bail!("invalid facet type, expecting {} found object", ftype),
+            Value::Object(_) => (),
         }
     }
 
-    let mut facet_values = SmallVec8::new();
-    inner_parse_facet_value(ftype, value, true, &mut facet_values)?;
-    Ok(facet_values)
+    let mut facet_number_values = Vec::new();
+    let mut facet_string_values = Vec::new();
+    inner_extract_facet_values(value, true, &mut facet_number_values, &mut facet_string_values);
+
+    (facet_number_values, facet_string_values)
 }

--- a/milli/src/update/index_documents/store.rs
+++ b/milli/src/update/index_documents/store.rs
@@ -23,7 +23,7 @@ use crate::heed_codec::facet::{FacetValueStringCodec, FacetLevelValueF64Codec};
 use crate::heed_codec::facet::{FieldDocIdFacetStringCodec, FieldDocIdFacetF64Codec};
 use crate::heed_codec::{BoRoaringBitmapCodec, CboRoaringBitmapCodec};
 use crate::update::UpdateIndexingStep;
-use crate::{json_to_string, SmallVec32, Position, DocumentId, FieldId, FieldsIdsMap};
+use crate::{json_to_string, SmallVec32, Position, DocumentId, FieldId};
 
 use super::{MergeFn, create_writer, create_sorter, writer_into_reader};
 use super::merge_function::{
@@ -53,8 +53,6 @@ pub struct Readers {
 
 pub struct Store<'s, A> {
     // Indexing parameters
-    primary_key: String,
-    fields_ids_map: FieldsIdsMap,
     searchable_fields: HashSet<FieldId>,
     faceted_fields: HashSet<FieldId>,
     // Caches
@@ -87,8 +85,6 @@ pub struct Store<'s, A> {
 
 impl<'s, A: AsRef<[u8]>> Store<'s, A> {
     pub fn new(
-        primary_key: String,
-        fields_ids_map: FieldsIdsMap,
         searchable_fields: HashSet<FieldId>,
         faceted_fields: HashSet<FieldId>,
         linked_hash_map_size: Option<usize>,
@@ -184,8 +180,6 @@ impl<'s, A: AsRef<[u8]>> Store<'s, A> {
 
         Ok(Store {
             // Indexing parameters.
-            primary_key,
-            fields_ids_map,
             searchable_fields,
             faceted_fields,
             // Caches


### PR DESCRIPTION
This pull request is related to https://github.com/meilisearch/milli/issues/152 and changes the layout of the facets values, numbers and strings are now in dedicated databases and the user no more needs to define the type of the fields. No more conversion between the two types is done, numbers (floats and integers converted to f64) go to the facet float database and strings go to the strings facet database.

There is one related issue that I found regarding CSVs, the values in a CSV are always considered to be strings, [meilisearch/specifications#28](https://github.com/meilisearch/specifications/blob/d916b57d748628c3b45500e9dfa46b50dfa2ad3f/text/0028-indexing-csv.md) fixes this issue by allowing the user to define the fields types using `:` in the "CSV Formatting Rules" section.

All previous tests on facets have been modified to pass again and I have also done hand-driven tests with the 115m songs dataset. Everything seems to be good!

Fixes #192.