### PR TITLE
Exactness criterion

### DIFF
--- a/milli/src/fields_ids_map.rs
+++ b/milli/src/fields_ids_map.rs
@@ -66,12 +66,12 @@ impl FieldsIdsMap {
         self.ids_names.iter().map(|(id, name)| (*id, name.as_str()))
     }
 
-    /// Iterate over the ids in the ids order.
+    /// Iterate over the ids in the order of the ids.
     pub fn ids<'a>(&'a self) -> impl Iterator<Item=FieldId> + 'a {
         self.ids_names.keys().copied()
     }
 
-    /// Iterate over the names in the ids order.
+    /// Iterate over the names in the order of the ids.
     pub fn names(&self) -> impl Iterator<Item=&str> {
         self.ids_names.values().map(AsRef::as_ref)
     }

--- a/milli/src/fields_ids_map.rs
+++ b/milli/src/fields_ids_map.rs
@@ -65,6 +65,16 @@ impl FieldsIdsMap {
     pub fn iter(&self) -> impl Iterator<Item=(FieldId, &str)> {
         self.ids_names.iter().map(|(id, name)| (*id, name.as_str()))
     }
+
+    /// Iterate over the ids in the ids order.
+    pub fn ids<'a>(&'a self) -> impl Iterator<Item=FieldId> + 'a {
+        self.ids_names.keys().copied()
+    }
+
+    /// Iterate over the names in the ids order.
+    pub fn names(&self) -> impl Iterator<Item=&str> {
+        self.ids_names.values().map(AsRef::as_ref)
+    }
 }
 
 impl Default for FieldsIdsMap {

--- a/milli/src/search/criteria/exactness.rs
+++ b/milli/src/search/criteria/exactness.rs
@@ -150,7 +150,25 @@ fn resolve_state(
 {
     use State::*;
     match state {
-        ExactAttribute(mut allowed_candidates) |
+        ExactAttribute(mut allowed_candidates) => {
+            let query_len = query.len() as u32;
+            let mut candidates = RoaringBitmap::new();
+            let attributes_ids = ctx.searchable_fields_ids()?;
+            for id in attributes_ids {
+                if let Some(attribute_allowed_docids) = ctx.field_id_len_docids(id, query_len)? {
+                    let mut attribute_candidates_array = attribute_start_with_docids(ctx, id as u32, query)?;
+                    attribute_candidates_array.push(attribute_allowed_docids);
+                    candidates |= intersection_of(attribute_candidates_array.iter().collect());
+                }
+            }
+
+            // only keep allowed candidates
+            candidates &= &allowed_candidates;
+            // remove current candidates from allowed candidates
+            allowed_candidates -= &candidates;
+            Ok((candidates, Some(AttributeStartsWith(allowed_candidates))))
+
+        },
         AttributeStartsWith(mut allowed_candidates) => {
             let mut candidates = RoaringBitmap::new();
             let attributes_ids = ctx.searchable_fields_ids()?;

--- a/milli/src/search/criteria/exactness.rs
+++ b/milli/src/search/criteria/exactness.rs
@@ -1,0 +1,335 @@
+use std::{collections::HashMap, mem};
+
+use log::debug;
+use roaring::RoaringBitmap;
+use itertools::Itertools;
+use std::ops::BitOr;
+
+use crate::search::query_tree::{Operation, PrimitiveQueryPart};
+use crate::search::criteria::{
+    Context,
+    Criterion,
+    CriterionParameters,
+    CriterionResult,
+    resolve_query_tree,
+};
+use crate::TreeLevel;
+
+pub struct Exactness<'t> {
+    ctx: &'t dyn Context<'t>,
+    query_tree: Option<Operation>,
+    state: Option<State>,
+    bucket_candidates: RoaringBitmap,
+    parent: Box<dyn Criterion + 't>,
+    query: Vec<ExactQueryPart>,
+}
+
+impl<'t> Exactness<'t> {
+    pub fn new(ctx: &'t dyn Context<'t>, parent: Box<dyn Criterion + 't>, primitive_query: &[PrimitiveQueryPart]) -> heed::Result<Self> {
+        let mut query: Vec<_> = Vec::with_capacity(primitive_query.len());
+        for part in primitive_query {
+            query.push(ExactQueryPart::from_primitive_query_part(ctx, part)?);
+        }
+
+        Ok(Exactness {
+            ctx,
+            query_tree: None,
+            state: None,
+            bucket_candidates: RoaringBitmap::new(),
+            parent,
+            query,
+        })
+    }
+}
+
+impl<'t> Criterion for Exactness<'t> {
+    #[logging_timer::time("Exactness::{}")]
+    fn next(&mut self, params: &mut CriterionParameters) -> anyhow::Result<Option<CriterionResult>> {
+        // remove excluded candidates when next is called, instead of doing it in the loop.
+        if let Some(state) = self.state.as_mut() {
+            state.difference_with(params.excluded_candidates);
+        }
+
+        loop {
+            debug!("Exactness for query {:?} at state {:?}", self.query, self.state);
+
+            match self.state.as_mut() {
+                Some(state) if state.is_empty() => {
+                    // reset state
+                    self.state = None;
+                    self.query_tree = None;
+                },
+                Some(state) => {
+                    let (candidates, state) = resolve_state(self.ctx, mem::take(state), &self.query)?;
+                    self.state = state;
+
+                    return Ok(Some(CriterionResult {
+                        query_tree: self.query_tree.clone(),
+                        candidates: Some(candidates),
+                        bucket_candidates: mem::take(&mut self.bucket_candidates),
+                    }));
+                },
+                None => {
+                    match self.parent.next(params)? {
+                        Some(CriterionResult { query_tree: Some(query_tree), candidates, bucket_candidates }) => {
+                            let candidates = match candidates {
+                                Some(candidates) => candidates,
+                                None => resolve_query_tree(self.ctx, &query_tree, &mut HashMap::new(), params.wdcache)?,
+                            };
+                            self.state = Some(State::new(candidates));
+                            self.query_tree = Some(query_tree);
+                            self.bucket_candidates |= bucket_candidates;
+                        },
+                        Some(CriterionResult { query_tree, candidates, bucket_candidates }) => {
+                            return Ok(Some(CriterionResult {
+                                query_tree,
+                                candidates,
+                                bucket_candidates,
+                            }));
+                        },
+                        None => return Ok(None),
+                    }
+                },
+            }
+         }
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    /// Extract the documents that have an attribute that contains exactly the query.
+    ExactAttribute(RoaringBitmap),
+    /// Extract the documents that have an attribute that starts with exactly the query.
+    AttributeStartsWith(RoaringBitmap),
+    /// Rank the remaining documents by the number of exact words contained.
+    ExactWords(RoaringBitmap),
+    Remainings(Vec<RoaringBitmap>),
+}
+
+impl State {
+    fn new(candidates: RoaringBitmap) -> Self {
+        Self::ExactAttribute(candidates)
+    }
+
+    fn difference_with(&mut self, lhs: &RoaringBitmap) {
+        match self {
+            Self::ExactAttribute(candidates) |
+            Self::AttributeStartsWith(candidates) |
+            Self::ExactWords(candidates) => *candidates -= lhs,
+            Self::Remainings(candidates_array) => {
+                candidates_array.iter_mut().for_each(|candidates| *candidates -= lhs);
+                candidates_array.retain(|candidates| !candidates.is_empty());
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::ExactAttribute(candidates) |
+            Self::AttributeStartsWith(candidates) |
+            Self::ExactWords(candidates) => candidates.is_empty(),
+            Self::Remainings(candidates_array) => {
+                candidates_array.iter().all(RoaringBitmap::is_empty)
+            }
+        }
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::Remainings(vec![])
+    }
+}
+
+#[logging_timer::time("Exactness::{}")]
+fn resolve_state(
+    ctx: &dyn Context,
+    state: State,
+    query: &[ExactQueryPart],
+) -> anyhow::Result<(RoaringBitmap, Option<State>)>
+{
+    use State::*;
+    match state {
+        ExactAttribute(mut allowed_candidates) |
+        AttributeStartsWith(mut allowed_candidates) => {
+            let mut candidates = RoaringBitmap::new();
+            let attributes_ids = ctx.searchable_fields_ids()?;
+            for id in attributes_ids {
+                let attribute_candidates_array = attribute_start_with_docids(ctx, id as u32, query)?;
+                candidates |= intersection_of(attribute_candidates_array.iter().collect());
+            }
+
+            // only keep allowed candidates
+            candidates &= &allowed_candidates;
+            // remove current candidates from allowed candidates
+            allowed_candidates -= &candidates;
+            Ok((candidates, Some(ExactWords(allowed_candidates))))
+        },
+        ExactWords(mut allowed_candidates) => {
+            let number_of_part = query.len();
+            let mut parts_candidates_array = Vec::with_capacity(number_of_part);
+
+            for part in query {
+                let mut candidates = RoaringBitmap::new();
+                use ExactQueryPart::*;
+                match part {
+                    Synonyms(synonyms) => {
+                        for synonym in synonyms {
+                            if let Some(synonym_candidates) = ctx.word_docids(synonym)? {
+                                candidates |= synonym_candidates;
+                            }
+                        }
+                    },
+                    // compute intersection on pair of words with a proximity of 0.
+                    Phrase(phrase) => {
+                        let mut bitmaps = Vec::with_capacity(phrase.len().saturating_sub(1));
+                        for words in phrase.windows(2) {
+                            if let [left, right] = words {
+                                match ctx.word_pair_proximity_docids(left, right, 0)? {
+                                    Some(docids) => bitmaps.push(docids),
+                                    None => {
+                                        bitmaps.clear();
+                                        break
+                                    },
+                                }
+                            }
+                        }
+                        candidates |= intersection_of(bitmaps.iter().collect());
+                    }
+                }
+                parts_candidates_array.push(candidates);
+            }
+
+            let mut candidates_array = Vec::new();
+
+            // compute documents that contain all exact words.
+            let mut all_exact_candidates = intersection_of(parts_candidates_array.iter().collect());
+            all_exact_candidates &= &allowed_candidates;
+            allowed_candidates -= &all_exact_candidates;
+
+            // push the result of combinations of exact words grouped by the number of exact words contained by documents.
+            for c_count in (1..number_of_part).rev() {
+                let mut combinations_candidates = parts_candidates_array
+                    .iter()
+                    // create all `c_count` combinations of exact words
+                    .combinations(c_count)
+                    // intersect each word candidates in combinations
+                    .map(intersection_of)
+                    // union combinations of `c_count` exact words
+                    .fold(RoaringBitmap::new(),  RoaringBitmap::bitor);
+                // only keep allowed candidates
+                combinations_candidates &= &allowed_candidates;
+                // remove current candidates from allowed candidates
+                allowed_candidates -= &combinations_candidates;
+                candidates_array.push(combinations_candidates);
+            }
+
+            // push remainings allowed candidates as the worst valid candidates
+            candidates_array.push(allowed_candidates);
+            // reverse the array to be able to pop candidates from the best to the worst.
+            candidates_array.reverse();
+
+            Ok((all_exact_candidates, Some(Remainings(candidates_array))))
+        },
+        // pop remainings candidates until the emptiness
+        Remainings(mut candidates_array) => {
+            let candidates = candidates_array.pop().unwrap_or_default();
+            if !candidates_array.is_empty() {
+                Ok((candidates, Some(Remainings(candidates_array))))
+            } else {
+                Ok((candidates, None))
+            }
+        },
+
+    }
+}
+
+fn attribute_start_with_docids(ctx: &dyn Context, attribute_id: u32, query: &[ExactQueryPart]) -> heed::Result<Vec<RoaringBitmap>> {
+    let lowest_level = TreeLevel::min_value();
+    let mut attribute_candidates_array = Vec::new();
+    // start from attribute first position
+    let mut pos = attribute_id * 1000;
+    for part in query {
+        use ExactQueryPart::*;
+        match part {
+            Synonyms(synonyms) => {
+                let mut synonyms_candidates = RoaringBitmap::new();
+                for word in synonyms {
+                    let wc = ctx.word_level_position_docids(word, lowest_level, pos, pos)?;
+                    if let Some(word_candidates) = wc {
+                        synonyms_candidates |= word_candidates;
+                    }
+                }
+                attribute_candidates_array.push(synonyms_candidates);
+                pos += 1;
+            },
+            Phrase(phrase) => {
+                for word in phrase {
+                    let wc = ctx.word_level_position_docids(word, lowest_level, pos, pos)?;
+                    if let Some(word_candidates) = wc {
+                        attribute_candidates_array.push(word_candidates);
+                    }
+                    pos += 1;
+                }
+            }
+        }
+    }
+
+    Ok(attribute_candidates_array)
+}
+
+fn intersection_of(mut to_intersect: Vec<&RoaringBitmap>) -> RoaringBitmap {
+    match to_intersect.len() {
+        0 => RoaringBitmap::new(),
+        1 => to_intersect[0].clone(),
+        2 => to_intersect[0] & to_intersect[1],
+        _ => {
+            to_intersect.sort_unstable_by(|a, b| a.len().cmp(&b.len()).reverse());
+
+            match to_intersect.pop() {
+                None => RoaringBitmap::new(),
+                Some(candidates)  => {
+                    let mut candidates = candidates.clone();
+                    while let Some(bitmap) = to_intersect.pop() {
+                        if candidates.is_empty() { break; }
+                        candidates &= bitmap;
+                    }
+
+                    candidates
+                },
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ExactQueryPart {
+    Phrase(Vec<String>),
+    Synonyms(Vec<String>),
+}
+
+impl ExactQueryPart {
+    fn from_primitive_query_part(ctx: &dyn Context, part: &PrimitiveQueryPart) -> heed::Result<Self> {
+        let part = match part {
+            PrimitiveQueryPart::Word(word, _) => {
+                match ctx.synonyms(word)? {
+                    Some(synonyms) => {
+                        let mut synonyms: Vec<_> = synonyms.into_iter().filter_map(|mut array| {
+                            // keep 1 word synonyms only.
+                            match array.pop() {
+                                Some(word) if array.is_empty() => Some(word),
+                                _ => None,
+                            }
+                        }).collect();
+                        synonyms.push(word.clone());
+                        ExactQueryPart::Synonyms(synonyms)
+                    },
+                    None => ExactQueryPart::Synonyms(vec![word.clone()]),
+                }
+            },
+            PrimitiveQueryPart::Phrase(phrase) => ExactQueryPart::Phrase(phrase.clone()),
+        };
+
+        Ok(part)
+    }
+}

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use anyhow::bail;
 use roaring::RoaringBitmap;
 
-use crate::{TreeLevel, search::{word_derivations, WordDerivationsCache}};
+use crate::{FieldId, TreeLevel, search::{word_derivations, WordDerivationsCache}};
 use crate::{Index, DocumentId};
 
 use super::query_tree::{Operation, PrimitiveQuery, PrimitiveQueryPart, Query, QueryKind};
@@ -84,7 +84,8 @@ pub trait Context<'c> {
     fn word_position_iterator(&self, word: &str, level: TreeLevel, in_prefix_cache: bool, left: Option<u32>, right: Option<u32>) -> heed::Result<Box<dyn Iterator<Item =heed::Result<((&'c str, TreeLevel, u32, u32), RoaringBitmap)>> + 'c>>;
     fn word_position_last_level(&self, word: &str, in_prefix_cache: bool) -> heed::Result<Option<TreeLevel>>;
     fn synonyms(&self, word: &str) -> heed::Result<Option<Vec<Vec<String>>>>;
-    fn searchable_fields_ids(&self) ->  heed::Result<Vec<crate::FieldId>>;
+    fn searchable_fields_ids(&self) ->  heed::Result<Vec<FieldId>>;
+    fn field_id_len_docids(&self, field_id: FieldId, len: u32) -> heed::Result<Option<RoaringBitmap>>;
     fn word_level_position_docids(&self, word: &str, level: TreeLevel, left: u32, right: u32) -> Result<Option<RoaringBitmap>, heed::Error>;
 }
 pub struct CriteriaBuilder<'t> {
@@ -180,12 +181,15 @@ impl<'c> Context<'c> for CriteriaBuilder<'c> {
         self.index.words_synonyms(self.rtxn, &[word])
     }
 
-    fn searchable_fields_ids(&self) -> heed::Result<Vec<crate::FieldId>> {
+    fn searchable_fields_ids(&self) -> heed::Result<Vec<FieldId>> {
         match self.index.searchable_fields_ids(self.rtxn)? {
             Some(searchable_fields_ids) => Ok(searchable_fields_ids),
             None => Ok(self.index.fields_ids_map(self.rtxn)?.ids().collect()),
         }
+    }
 
+    fn field_id_len_docids(&self, field_id: FieldId, len: u32) -> heed::Result<Option<RoaringBitmap>> {
+        Ok(None)
     }
 
     fn word_level_position_docids(&self, word: &str, level: TreeLevel, left: u32, right: u32) -> Result<Option<RoaringBitmap>, heed::Error> {
@@ -486,11 +490,15 @@ pub mod test {
             todo!()
         }
 
-        fn searchable_fields_ids(&self) ->  heed::Result<Vec<crate::FieldId>> {
+        fn searchable_fields_ids(&self) ->  heed::Result<Vec<FieldId>> {
             todo!()
         }
 
         fn word_level_position_docids(&self, word: &str, level: TreeLevel, left: u32, right: u32) -> Result<Option<RoaringBitmap>, heed::Error> {
+            todo!()
+        }
+
+        fn field_id_len_docids(&self, field_id: FieldId, len: u32) -> heed::Result<Option<RoaringBitmap>> {
             todo!()
         }
     }

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -7,7 +7,7 @@ use roaring::RoaringBitmap;
 use crate::{FieldId, TreeLevel, search::{word_derivations, WordDerivationsCache}};
 use crate::{Index, DocumentId};
 
-use super::query_tree::{Operation, PrimitiveQuery, PrimitiveQueryPart, Query, QueryKind};
+use super::query_tree::{Operation, PrimitiveQueryPart, Query, QueryKind};
 use self::asc_desc::AscDesc;
 use self::attribute::Attribute;
 use self::exactness::Exactness;
@@ -188,7 +188,7 @@ impl<'c> Context<'c> for CriteriaBuilder<'c> {
         }
     }
 
-    fn field_id_len_docids(&self, field_id: FieldId, len: u32) -> heed::Result<Option<RoaringBitmap>> {
+    fn field_id_len_docids(&self, _field_id: FieldId, _len: u32) -> heed::Result<Option<RoaringBitmap>> {
         Ok(None)
     }
 
@@ -226,7 +226,6 @@ impl<'t> CriteriaBuilder<'t> {
                 Name::Exactness => Box::new(Exactness::new(self, criterion, &primitive_query)?),
                 Name::Asc(field) => Box::new(AscDesc::asc(&self.index, &self.rtxn, criterion, field)?),
                 Name::Desc(field) => Box::new(AscDesc::desc(&self.index, &self.rtxn, criterion, field)?),
-                _otherwise => criterion,
             };
         }
 
@@ -486,7 +485,7 @@ pub mod test {
             todo!()
         }
 
-        fn synonyms(&self, word: &str) -> heed::Result<Option<Vec<Vec<String>>>> {
+        fn synonyms(&self, _word: &str) -> heed::Result<Option<Vec<Vec<String>>>> {
             todo!()
         }
 
@@ -494,11 +493,11 @@ pub mod test {
             todo!()
         }
 
-        fn word_level_position_docids(&self, word: &str, level: TreeLevel, left: u32, right: u32) -> Result<Option<RoaringBitmap>, heed::Error> {
+        fn word_level_position_docids(&self, _word: &str, _level: TreeLevel, _left: u32, _right: u32) -> Result<Option<RoaringBitmap>, heed::Error> {
             todo!()
         }
 
-        fn field_id_len_docids(&self, field_id: FieldId, len: u32) -> heed::Result<Option<RoaringBitmap>> {
+        fn field_id_len_docids(&self, _field_id: FieldId, _len: u32) -> heed::Result<Option<RoaringBitmap>> {
             todo!()
         }
     }


### PR DESCRIPTION
- [ ] (future PR) Rule 1: Fetch documents that have an attributes that contains exactly the Query and only the Query.
- [x]  Rule 2: Fetch documents that have an attributes starting by the Query.
- [x]  Rule 3: Fetch documents that contains the words of the Query anywhere. 

Related to #165 