### PR TITLE
Fix the benchmarks script and names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "helpers"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "byte-unit",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "http-ui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "infos"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "byte-unit",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "milli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "big_s",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "search"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "byte-unit",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ milli = { path = "../milli" }
 
 [dev-dependencies]
 heed = "*" # we want to use the version milli uses
-criterion = "0.3.4"
+criterion = { version = "0.3.4", features = ["html_reports"] }
 
 [build-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
The benchmarks compare script was not using the `--output` flag and was therefore failing the download of the JSON reports. We also modified the criterion benchmarks to use shorter names, it helps in looking at the benchmarks in the terminal.