### PR TITLE
Save the criteria field name in the fields ids map

### DIFF
--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -30,6 +30,16 @@ pub enum Criterion {
     Desc(String),
 }
 
+impl Criterion {
+    /// Returns the field name parameter of this criterion.
+    pub fn field_name(&self) -> Option<&str> {
+        match self {
+            Criterion::Asc(name) | Criterion::Desc(name) => Some(name),
+            _otherwise => None,
+        }
+    }
+}
+
 impl FromStr for Criterion {
     type Err = anyhow::Error;
 

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -697,7 +697,7 @@ mod tests {
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = Settings::new(&mut wtxn, &index, 0);
         // Don't display the generated `id` field.
-        builder.set_displayed_fields(vec![S("name"), S("age")]);
+        builder.set_displayed_fields(vec![S("name")]);
         builder.set_criteria(vec![S("asc(age)")]);
         builder.execute(|_, _| ()).unwrap();
 


### PR DESCRIPTION
We now make sure that we insert the new field name into the fields-ids-map when we are creating and modifying the criteria. Previously the engine was throwing an error due to that if the field was missing in the fields ids map.