### PR TITLE
Revert "Enable optimization in every profile"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ opt-level = 3
 [profile.release]
 debug = true
 
-[profile.test]
-opt-level = 3
-
 # Make sure that the build scripts and proc-macros are compiled with
 # all the optimizations. It speeds up the zip crate that we use in the build.rs.
 [profile.dev.build-override]


### PR DESCRIPTION
compiling tests in release takes too much time.

Reverts meilisearch/milli#224

Fix #233 