### PR TITLE
change sub errors visibility

### DIFF
--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -22,7 +22,7 @@ use fxhash::{FxHasher32, FxHasher64};
 use serde_json::{Map, Value};
 
 pub use self::criterion::{default_criteria, Criterion};
-pub use self::error::Error;
+pub use self::error::{Error, InternalError, UserError};
 pub use self::external_documents_ids::ExternalDocumentsIds;
 pub use self::fields_ids_map::FieldsIdsMap;
 pub use self::heed_codec::{

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -22,7 +22,7 @@ use fxhash::{FxHasher32, FxHasher64};
 use serde_json::{Map, Value};
 
 pub use self::criterion::{default_criteria, Criterion};
-pub use self::error::{Error, InternalError, UserError};
+pub use self::error::{Error, FieldIdMapMissingEntry, InternalError, SerializationError, UserError};
 pub use self::external_documents_ids::ExternalDocumentsIds;
 pub use self::fields_ids_map::FieldsIdsMap;
 pub use self::heed_codec::{


### PR DESCRIPTION
re-export sub-error types so they can be matched upon outside of milli.
