### PR TITLE
Return a `MissingDocumentId` error when a document doesn't have one

### DIFF
--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -206,7 +206,13 @@ impl fmt::Display for UserError {
             Self::InvalidCriterionName { name } => write!(f, "invalid criterion {}", name),
             Self::InvalidDocumentId { document_id } => {
                 let json = serde_json::to_string(document_id).unwrap();
-                write!(f, "document identifier is invalid {}", json)
+                write!(
+                    f,
+                    "document identifier is invalid {}, \
+a document id can be of type integer or string \
+only composed of alphanumeric characters (a-z A-Z 0-9), hyphens (-) and underscores (_)",
+                    json
+                )
             }
             Self::InvalidFilterAttribute(error) => error.fmt(f),
             Self::MissingDocumentId { document } => {

--- a/milli/src/update/index_documents/transform.rs
+++ b/milli/src/update/index_documents/transform.rs
@@ -18,7 +18,7 @@ use crate::index::db_name;
 use crate::update::index_documents::merge_function::{keep_latest_obkv, merge_obkvs};
 use crate::update::{AvailableDocumentsIds, UpdateIndexingStep};
 use crate::{
-    ExternalDocumentsIds, FieldId, FieldDistribution, FieldsIdsMap, Index, MergeFn, Result, BEU32,
+    ExternalDocumentsIds, FieldDistribution, FieldId, FieldsIdsMap, Index, MergeFn, Result, BEU32,
 };
 
 const DEFAULT_PRIMARY_KEY_NAME: &str = "id";
@@ -190,7 +190,7 @@ impl Transform<'_, '_> {
                 },
                 None => {
                     if !self.autogenerate_docids {
-                        return Err(UserError::MissingPrimaryKey.into());
+                        return Err(UserError::MissingDocumentId { document }.into());
                     }
                     let uuid = uuid::Uuid::new_v4().to_hyphenated().encode_lower(&mut uuid_buffer);
                     Cow::Borrowed(uuid)


### PR DESCRIPTION
We were wrongly returning a `MissingPrimaryKey` instead of a `MissingDocumentId` error for when a document was missing a document id. We also improved the error message for when a document id is invalid (wrong type or wrong format).