### PR TITLE
Fix the limit

### DIFF
--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -162,7 +162,7 @@ impl<'a> Search<'a> {
         let mut offset = self.offset;
         let mut initial_candidates = RoaringBitmap::new();
         let mut excluded_candidates = RoaringBitmap::new();
-        let mut documents_ids = Vec::with_capacity(self.limit);
+        let mut documents_ids = Vec::new();
 
         while let Some(FinalResult { candidates, bucket_candidates, .. }) =
             criteria.next(&excluded_candidates)?


### PR DESCRIPTION
There was no check on the limit and thus if a user specified a very large number this line could cause a panic.