### PR TITLE
Fix bug when inserting previously deleted documents

### DIFF
--- a/milli/src/external_documents_ids.rs
+++ b/milli/src/external_documents_ids.rs
@@ -1,7 +1,11 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::convert::TryInto;
+use std::{fmt, str};
 
 use fst::{IntoStreamer, Streamer};
+
+const DELETED_ID: u64 = u64::MAX;
 
 pub struct ExternalDocumentsIds<'a> {
     pub(crate) hard: fst::Map<Cow<'a, [u8]>>,
@@ -32,7 +36,7 @@ impl<'a> ExternalDocumentsIds<'a> {
         let external_id = external_id.as_ref();
         match self.soft.get(external_id).or_else(|| self.hard.get(external_id)) {
             // u64 MAX means deleted in the soft fst map
-            Some(id) if id != u64::MAX => Some(id.try_into().unwrap()),
+            Some(id) if id != DELETED_ID => Some(id.try_into().unwrap()),
             _otherwise => None,
         }
     }
@@ -47,7 +51,7 @@ impl<'a> ExternalDocumentsIds<'a> {
             if docids.iter().any(|v| v.index == 1) {
                 // If the `other` set returns a value here it means
                 // that it must be marked as deleted.
-                new_soft_builder.insert(external_id, u64::MAX)?;
+                new_soft_builder.insert(external_id, DELETED_ID)?;
             } else {
                 new_soft_builder.insert(external_id, docids[0].value)?;
             }
@@ -77,6 +81,24 @@ impl<'a> ExternalDocumentsIds<'a> {
         self.merge_soft_into_hard()
     }
 
+    /// An helper function to debug this type, returns an `HashMap` of both,
+    /// soft and hard fst maps, combined.
+    pub fn to_hash_map(&self) -> HashMap<String, u32> {
+        let mut map = HashMap::new();
+
+        let union_op = self.hard.op().add(&self.soft).r#union();
+        let mut iter = union_op.into_stream();
+        while let Some((external_id, marked_docids)) = iter.next() {
+            let id = marked_docids.last().unwrap().value;
+            if id != DELETED_ID {
+                let external_id = str::from_utf8(external_id).unwrap();
+                map.insert(external_id.to_owned(), id.try_into().unwrap());
+            }
+        }
+
+        map
+    }
+
     fn merge_soft_into_hard(&mut self) -> fst::Result<()> {
         if self.soft.len() >= self.hard.len() / 2 {
             let union_op = self.hard.op().add(&self.soft).r#union();
@@ -85,7 +107,7 @@ impl<'a> ExternalDocumentsIds<'a> {
             let mut new_hard_builder = fst::MapBuilder::memory();
             while let Some((external_id, docids)) = iter.next() {
                 if docids.len() == 2 {
-                    if docids[1].value != u64::MAX {
+                    if docids[1].value != DELETED_ID {
                         new_hard_builder.insert(external_id, docids[1].value)?;
                     }
                 } else {
@@ -100,6 +122,12 @@ impl<'a> ExternalDocumentsIds<'a> {
         }
 
         Ok(())
+    }
+}
+
+impl fmt::Debug for ExternalDocumentsIds<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("ExternalDocumentsIds").field(&self.to_hash_map()).finish()
     }
 }
 

--- a/milli/src/external_documents_ids.rs
+++ b/milli/src/external_documents_ids.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::{fmt, str};
 
+use fst::map::IndexedValue;
 use fst::{IntoStreamer, Streamer};
 
 const DELETED_ID: u64 = u64::MAX;
@@ -35,7 +36,6 @@ impl<'a> ExternalDocumentsIds<'a> {
     pub fn get<A: AsRef<[u8]>>(&self, external_id: A) -> Option<u32> {
         let external_id = external_id.as_ref();
         match self.soft.get(external_id).or_else(|| self.hard.get(external_id)) {
-            // u64 MAX means deleted in the soft fst map
             Some(id) if id != DELETED_ID => Some(id.try_into().unwrap()),
             _otherwise => None,
         }
@@ -53,7 +53,8 @@ impl<'a> ExternalDocumentsIds<'a> {
                 // that it must be marked as deleted.
                 new_soft_builder.insert(external_id, DELETED_ID)?;
             } else {
-                new_soft_builder.insert(external_id, docids[0].value)?;
+                let value = docids.iter().find(|v| v.index == 0).unwrap().value;
+                new_soft_builder.insert(external_id, value)?;
             }
         }
 
@@ -69,8 +70,8 @@ impl<'a> ExternalDocumentsIds<'a> {
 
         let mut new_soft_builder = fst::MapBuilder::memory();
         let mut iter = union_op.into_stream();
-        while let Some((external_id, docids)) = iter.next() {
-            let id = docids.last().unwrap().value;
+        while let Some((external_id, marked_docids)) = iter.next() {
+            let id = indexed_last_value(marked_docids).unwrap();
             new_soft_builder.insert(external_id, id)?;
         }
 
@@ -89,7 +90,7 @@ impl<'a> ExternalDocumentsIds<'a> {
         let union_op = self.hard.op().add(&self.soft).r#union();
         let mut iter = union_op.into_stream();
         while let Some((external_id, marked_docids)) = iter.next() {
-            let id = marked_docids.last().unwrap().value;
+            let id = indexed_last_value(marked_docids).unwrap();
             if id != DELETED_ID {
                 let external_id = str::from_utf8(external_id).unwrap();
                 map.insert(external_id.to_owned(), id.try_into().unwrap());
@@ -105,13 +106,10 @@ impl<'a> ExternalDocumentsIds<'a> {
 
             let mut iter = union_op.into_stream();
             let mut new_hard_builder = fst::MapBuilder::memory();
-            while let Some((external_id, docids)) = iter.next() {
-                if docids.len() == 2 {
-                    if docids[1].value != DELETED_ID {
-                        new_hard_builder.insert(external_id, docids[1].value)?;
-                    }
-                } else {
-                    new_hard_builder.insert(external_id, docids[0].value)?;
+            while let Some((external_id, marked_docids)) = iter.next() {
+                let value = indexed_last_value(marked_docids).unwrap();
+                if value != DELETED_ID {
+                    new_hard_builder.insert(external_id, value)?;
                 }
             }
 
@@ -138,6 +136,11 @@ impl Default for ExternalDocumentsIds<'static> {
             soft: fst::Map::default().map_data(Cow::Owned).unwrap(),
         }
     }
+}
+
+/// Returns the value of the `IndexedValue` with the highest _index_.
+fn indexed_last_value(indexed_values: &[IndexedValue]) -> Option<u64> {
+    indexed_values.iter().copied().max_by_key(|iv| iv.index).map(|iv| iv.value)
 }
 
 #[cfg(test)]
@@ -189,5 +192,26 @@ mod tests {
         assert_eq!(external_documents_ids.get("f"), None);
         assert_eq!(external_documents_ids.get("g"), Some(7));
         assert_eq!(external_documents_ids.get("h"), Some(8));
+    }
+
+    #[test]
+    fn strange_delete_insert_ids() {
+        let mut external_documents_ids = ExternalDocumentsIds::default();
+
+        let new_ids =
+            fst::Map::from_iter(vec![("1", 0), ("123", 1), ("30", 2), ("456", 3)]).unwrap();
+        external_documents_ids.insert_ids(&new_ids).unwrap();
+        assert_eq!(external_documents_ids.get("1"), Some(0));
+        assert_eq!(external_documents_ids.get("123"), Some(1));
+        assert_eq!(external_documents_ids.get("30"), Some(2));
+        assert_eq!(external_documents_ids.get("456"), Some(3));
+
+        let deleted_ids = fst::Set::from_iter(vec!["30"]).unwrap();
+        external_documents_ids.delete_ids(deleted_ids).unwrap();
+        assert_eq!(external_documents_ids.get("30"), None);
+
+        let new_ids = fst::Map::from_iter(vec![("30", 2)]).unwrap();
+        external_documents_ids.insert_ids(&new_ids).unwrap();
+        assert_eq!(external_documents_ids.get("30"), Some(2));
     }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -218,7 +218,7 @@ impl Index {
     }
 
     /// Deletes the primary key of the documents, this can be done to reset indexes settings.
-    pub fn delete_primary_key(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_primary_key(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::PRIMARY_KEY_KEY)
     }
 
@@ -333,7 +333,7 @@ impl Index {
 
     /// Deletes the displayed fields ids, this will make the engine to display
     /// all the documents attributes in the order of the `FieldsIdsMap`.
-    pub fn delete_displayed_fields(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_displayed_fields(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::DISPLAYED_FIELDS_KEY)
     }
 
@@ -383,7 +383,7 @@ impl Index {
     }
 
     /// Deletes the searchable fields, when no fields are specified, all fields are indexed.
-    pub fn delete_searchable_fields(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_searchable_fields(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::SEARCHABLE_FIELDS_KEY)
     }
 
@@ -429,7 +429,7 @@ impl Index {
     }
 
     /// Deletes the filterable fields ids in the database.
-    pub fn delete_filterable_fields(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_filterable_fields(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::FILTERABLE_FIELDS_KEY)
     }
 
@@ -602,7 +602,7 @@ impl Index {
         self.main.put::<_, Str, SerdeJson<&[Criterion]>>(wtxn, main_key::CRITERIA_KEY, &criteria)
     }
 
-    pub fn delete_criteria(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_criteria(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::CRITERIA_KEY)
     }
 
@@ -642,7 +642,7 @@ impl Index {
         self.main.put::<_, Str, ByteSlice>(wtxn, main_key::STOP_WORDS_KEY, fst.as_fst().as_bytes())
     }
 
-    pub fn delete_stop_words(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_stop_words(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::STOP_WORDS_KEY)
     }
 
@@ -663,7 +663,7 @@ impl Index {
         self.main.put::<_, Str, SerdeBincode<_>>(wtxn, main_key::SYNONYMS_KEY, synonyms)
     }
 
-    pub fn delete_synonyms(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
+    pub(crate) fn delete_synonyms(&self, wtxn: &mut RwTxn) -> heed::Result<bool> {
         self.main.delete::<_, Str>(wtxn, main_key::SYNONYMS_KEY)
     }
 

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -845,6 +845,7 @@ mod tests {
     use heed::EnvOpenOptions;
 
     use super::*;
+    use crate::update::DeleteDocuments;
 
     #[test]
     fn simple_document_replacement() {
@@ -1301,6 +1302,54 @@ mod tests {
         ]"#[..];
 
         builder.execute(Cursor::new(documents), |_, _| ()).unwrap();
+        wtxn.commit().unwrap();
+    }
+
+    #[test]
+    fn delete_documents_then_insert() {
+        let path = tempfile::tempdir().unwrap();
+        let mut options = EnvOpenOptions::new();
+        options.map_size(10 * 1024 * 1024); // 10 MB
+        let index = Index::new(options, &path).unwrap();
+
+        let mut wtxn = index.write_txn().unwrap();
+        let content = &br#"[
+            { "objectId": 123, "title": "Pride and Prejudice", "comment": "A great book" },
+            { "objectId": 456, "title": "Le Petit Prince",     "comment": "A french book" },
+            { "objectId": 1,   "title": "Alice In Wonderland", "comment": "A weird book" },
+            { "objectId": 30,  "title": "Hamlet" }
+        ]"#[..];
+        let mut builder = IndexDocuments::new(&mut wtxn, &index, 0);
+        builder.update_format(UpdateFormat::Json);
+        builder.execute(content, |_, _| ()).unwrap();
+
+        assert_eq!(index.primary_key(&wtxn).unwrap(), Some("objectId"));
+
+        // Delete not all of the documents but some of them.
+        let mut builder = DeleteDocuments::new(&mut wtxn, &index, 1).unwrap();
+        builder.delete_external_id("30");
+        builder.execute().unwrap();
+
+        let external_documents_ids = index.external_documents_ids(&wtxn).unwrap();
+        assert!(external_documents_ids.get("30").is_none());
+
+        let content = &br#"[
+            { "objectId": 30, "title": "Hamlet" }
+        ]"#[..];
+        let mut builder = IndexDocuments::new(&mut wtxn, &index, 0);
+        builder.update_format(UpdateFormat::Json);
+        builder.execute(content, |_, _| ()).unwrap();
+
+        let external_documents_ids = index.external_documents_ids(&wtxn).unwrap();
+        assert!(external_documents_ids.get("30").is_some());
+
+        let content = &br#"[
+            { "objectId": 30, "title": "Hamlet" }
+        ]"#[..];
+        let mut builder = IndexDocuments::new(&mut wtxn, &index, 0);
+        builder.update_format(UpdateFormat::Json);
+        builder.execute(content, |_, _| ()).unwrap();
+
         wtxn.commit().unwrap();
     }
 }


### PR DESCRIPTION
This PR fixes #268.

The issue was in the `ExternalDocumentsIds` implementation in the specific case that an external document id was in the soft map marked as deleted.

The bug was due to a wrong assumption on my side about how the FST unions were returning the `IndexedValue`s, I thought the values returned in an array were in the same order as the FSTs given to the `OpBuilder` but in fact, [the `IndexedValue`'s `index` field was here to indicate from which FST the values were coming from](https://docs.rs/fst/0.4.7/fst/map/struct.IndexedValue.html).