### PR TITLE
Remove the roaring operation functions warnings

### DIFF
--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -328,7 +328,7 @@ pub fn resolve_query_tree<'t>(
                         candidates = docids;
                         first_loop = false;
                     } else {
-                        candidates.intersect_with(&docids);
+                        candidates &= &docids;
                     }
                 }
                 Ok(candidates)
@@ -358,7 +358,7 @@ pub fn resolve_query_tree<'t>(
                 let mut candidates = RoaringBitmap::new();
                 for op in ops {
                     let docids = resolve_operation(ctx, op, wdcache)?;
-                    candidates.union_with(&docids);
+                    candidates |= docids;
                 }
                 Ok(candidates)
             }
@@ -381,7 +381,7 @@ fn all_word_pair_proximity_docids<T: AsRef<str>, U: AsRef<str>>(
             let current_docids = ctx
                 .word_pair_proximity_docids(left.as_ref(), right.as_ref(), proximity)?
                 .unwrap_or_default();
-            docids.union_with(&current_docids);
+            docids |= current_docids;
         }
     }
     Ok(docids)
@@ -401,7 +401,7 @@ fn query_docids(
                 let mut docids = RoaringBitmap::new();
                 for (word, _typo) in words {
                     let current_docids = ctx.word_docids(&word)?.unwrap_or_default();
-                    docids.union_with(&current_docids);
+                    docids |= current_docids;
                 }
                 Ok(docids)
             } else {
@@ -413,7 +413,7 @@ fn query_docids(
             let mut docids = RoaringBitmap::new();
             for (word, _typo) in words {
                 let current_docids = ctx.word_docids(&word)?.unwrap_or_default();
-                docids.union_with(&current_docids);
+                docids |= current_docids;
             }
             Ok(docids)
         }
@@ -430,7 +430,7 @@ fn query_pair_proximity_docids(
     if proximity >= 8 {
         let mut candidates = query_docids(ctx, left, wdcache)?;
         let right_candidates = query_docids(ctx, right, wdcache)?;
-        candidates.intersect_with(&right_candidates);
+        candidates &= right_candidates;
         return Ok(candidates);
     }
 
@@ -463,7 +463,7 @@ fn query_pair_proximity_docids(
                             proximity,
                         )?
                         .unwrap_or_default();
-                    docids.union_with(&current_docids);
+                    docids |= current_docids;
                 }
                 Ok(docids)
             } else if prefix {

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -274,11 +274,11 @@ fn resolve_candidates<'t>(
                         let mut candidates =
                             query_pair_proximity_docids(ctx, lr, rl, pair_p + 1, wdcache)?;
                         if lcandidates.len() < rcandidates.len() {
-                            candidates.intersect_with(lcandidates);
-                            candidates.intersect_with(rcandidates);
+                            candidates &= lcandidates;
+                            candidates &= rcandidates;
                         } else {
-                            candidates.intersect_with(rcandidates);
-                            candidates.intersect_with(lcandidates);
+                            candidates &= rcandidates;
+                            candidates &= lcandidates;
                         }
                         if !candidates.is_empty() {
                             output.push((ll.clone(), rr.clone(), candidates));
@@ -317,7 +317,7 @@ fn resolve_candidates<'t>(
                             for (_, rtail, mut candidates) in
                                 mdfs(ctx, tail, proximity - p, cache, wdcache)?
                             {
-                                candidates.intersect_with(&head_candidates);
+                                candidates &= &head_candidates;
                                 if !candidates.is_empty() {
                                     output.push((lhead.clone(), rtail, candidates));
                                 }
@@ -334,7 +334,7 @@ fn resolve_candidates<'t>(
 
     let mut candidates = RoaringBitmap::new();
     for (_, _, cds) in resolve_operation(ctx, query_tree, proximity, cache, wdcache)? {
-        candidates.union_with(&cds);
+        candidates |= cds;
     }
     Ok(candidates)
 }

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -281,7 +281,7 @@ fn resolve_candidates<'t>(
                 let mut candidates = RoaringBitmap::new();
                 for op in ops {
                     let docids = resolve_operation(ctx, op, number_typos, cache, wdcache)?;
-                    candidates.union_with(&docids);
+                    candidates |= docids;
                 }
                 Ok(candidates)
             }
@@ -329,8 +329,8 @@ fn resolve_candidates<'t>(
                     };
                     if !head_candidates.is_empty() {
                         let tail_candidates = mdfs(ctx, tail, mana - m, cache, wdcache)?;
-                        head_candidates.intersect_with(&tail_candidates);
-                        candidates.union_with(&head_candidates);
+                        head_candidates &= tail_candidates;
+                        candidates |= head_candidates;
                     }
                 }
 

--- a/milli/src/search/distinct/facet_distinct.rs
+++ b/milli/src/search/distinct/facet_distinct.rs
@@ -61,7 +61,7 @@ impl<'a> FacetDistinctIter<'a> {
                     db_name: db_name::FACET_ID_STRING_DOCIDS,
                     key: None,
                 })?;
-            self.excluded.union_with(&facet_docids);
+            self.excluded |= facet_docids;
         }
 
         self.excluded.remove(id);
@@ -79,7 +79,7 @@ impl<'a> FacetDistinctIter<'a> {
                     db_name: db_name::FACET_ID_F64_DOCIDS,
                     key: None,
                 })?;
-            self.excluded.union_with(&facet_docids);
+            self.excluded |= facet_docids;
         }
 
         self.excluded.remove(id);
@@ -92,7 +92,7 @@ impl<'a> FacetDistinctIter<'a> {
     /// handling easier.
     fn next_inner(&mut self) -> Result<Option<DocumentId>> {
         // The first step is to remove all the excluded documents from our candidates
-        self.candidates.difference_with(&self.excluded);
+        self.candidates -= &self.excluded;
 
         let mut candidates_iter = self.candidates.iter().skip(self.iter_offset);
         match candidates_iter.next() {

--- a/milli/src/search/facet/facet_distribution.rs
+++ b/milli/src/search/facet/facet_distribution.rs
@@ -122,7 +122,7 @@ impl<'a> FacetDistribution<'a> {
 
         for result in iter {
             let (value, mut docids) = result?;
-            docids.intersect_with(candidates);
+            docids &= candidates;
             if !docids.is_empty() {
                 distribution.insert(value.to_string(), docids.len());
             }

--- a/milli/src/search/facet/filter_condition.rs
+++ b/milli/src/search/facet/filter_condition.rs
@@ -289,7 +289,7 @@ impl FilterCondition {
         for (i, result) in iter.enumerate() {
             let ((_fid, level, l, r), docids) = result?;
             debug!("{:?} to {:?} (level {}) found {} documents", l, r, level, docids.len());
-            output.union_with(&docids);
+            *output |= docids;
             // We save the leftest and rightest bounds we actually found at this level.
             if i == 0 {
                 left_found = Some(l);

--- a/milli/src/search/facet/mod.rs
+++ b/milli/src/search/facet/mod.rs
@@ -213,10 +213,10 @@ impl<'t> Iterator for FacetIter<'t> {
 
                 match result {
                     Ok(((_fid, level, left, right), mut docids)) => {
-                        docids.intersect_with(&documents_ids);
+                        docids &= &*documents_ids;
                         if !docids.is_empty() {
                             if self.must_reduce {
-                                documents_ids.difference_with(&docids);
+                                *documents_ids -= &docids;
                             }
 
                             if level == 0 {

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -173,7 +173,7 @@ impl<'a> Search<'a> {
 
             let mut candidates = distinct.distinct(candidates, excluded);
 
-            initial_candidates.union_with(&bucket_candidates);
+            initial_candidates |= bucket_candidates;
 
             if offset != 0 {
                 let discarded = candidates.by_ref().take(offset).count();

--- a/milli/src/update/available_documents_ids.rs
+++ b/milli/src/update/available_documents_ids.rs
@@ -12,7 +12,7 @@ impl AvailableDocumentsIds {
         match docids.max() {
             Some(last_id) => {
                 let mut available = RoaringBitmap::from_iter(0..last_id);
-                available.difference_with(&docids);
+                available -= docids;
 
                 let iter = match last_id.checked_add(1) {
                     Some(id) => id..=u32::max_value(),

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -181,7 +181,7 @@ fn compute_facet_number_levels<'t>(
             }
 
             // The right bound is always the bound we run through.
-            group_docids.union_with(&docids);
+            group_docids |= docids;
             right = value;
         }
 

--- a/milli/src/update/index_documents/merge_function.rs
+++ b/milli/src/update/index_documents/merge_function.rs
@@ -61,8 +61,7 @@ pub fn roaring_bitmap_merge(_key: &[u8], values: &[Cow<[u8]>]) -> Result<Vec<u8>
     let mut head = RoaringBitmap::deserialize_from(&head[..])?;
 
     for value in tail {
-        let bitmap = RoaringBitmap::deserialize_from(&value[..])?;
-        head.union_with(&bitmap);
+        head |= RoaringBitmap::deserialize_from(&value[..])?;
     }
 
     let mut vec = Vec::with_capacity(head.serialized_size());
@@ -75,8 +74,7 @@ pub fn cbo_roaring_bitmap_merge(_key: &[u8], values: &[Cow<[u8]>]) -> Result<Vec
     let mut head = CboRoaringBitmapCodec::deserialize_from(&head[..])?;
 
     for value in tail {
-        let bitmap = CboRoaringBitmapCodec::deserialize_from(&value[..])?;
-        head.union_with(&bitmap);
+        head |= CboRoaringBitmapCodec::deserialize_from(&value[..])?;
     }
 
     let mut vec = Vec::new();

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -608,8 +608,8 @@ impl<'t, 'u, 'i, 'a> IndexDocuments<'t, 'u, 'i, 'a> {
         self.index.put_external_documents_ids(self.wtxn, &external_documents_ids)?;
 
         // We merge the new documents ids with the existing ones.
-        documents_ids.union_with(&new_documents_ids);
-        documents_ids.union_with(&replaced_documents_ids);
+        documents_ids |= new_documents_ids;
+        documents_ids |= replaced_documents_ids;
         self.index.put_documents_ids(self.wtxn, &documents_ids)?;
 
         let mut database_count = 0;

--- a/milli/src/update/words_level_positions.rs
+++ b/milli/src/update/words_level_positions.rs
@@ -236,7 +236,7 @@ fn compute_positions_levels(
                 }
 
                 // The right bound is always the bound we run through.
-                group_docids.union_with(&docids);
+                group_docids |= docids;
             }
 
             if !group_docids.is_empty() {


### PR DESCRIPTION
In this PR we are just replacing the usages of the roaring operations function by the new operators. This removes a lot of warnings.