### PR TITLE
[http-ui] Introduce the route `die`

### DIFF
--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -983,7 +983,9 @@ async fn main() -> anyhow::Result<()> {
         });
 
     let die_route = warp::filters::method::get().and(warp::path!("die")).map(move || {
+        eprintln!("Killed by an HTTP request received on the die route");
         std::process::exit(0);
+        #[allow(unreachable_code)]
         warp::reply()
     });
 

--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -982,6 +982,11 @@ async fn main() -> anyhow::Result<()> {
             })
         });
 
+    let die_route = warp::filters::method::get().and(warp::path!("die")).map(move || {
+        std::process::exit(0);
+        warp::reply()
+    });
+
     let routes = dash_html_route
         .or(updates_list_or_html_route)
         .or(dash_bulma_route)
@@ -1001,7 +1006,8 @@ async fn main() -> anyhow::Result<()> {
         .or(clearing_route)
         .or(change_settings_route)
         .or(change_facet_levels_route)
-        .or(update_ws_route);
+        .or(update_ws_route)
+        .or(die_route);
 
     let addr = SocketAddr::from_str(&opt.http_listen_addr)?;
     warp::serve(routes).run(addr).await;


### PR DESCRIPTION
This route just `exit` the process. This can come in handy when you run `http-ui` inside of another process (a profiler for example), and you don't want to kill everything