### PR TITLE
Update version for the next release (v0.10.0)

### DIFF
--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/search/Cargo.toml
+++ b/search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "search"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Replaces https://github.com/meilisearch/milli/pull/304