### PR TITLE
Run all benchmarks once every friday

### DIFF
--- a/.github/workflows/cron_benchmarks_indexing.yml
+++ b/.github/workflows/cron_benchmarks_indexing.yml
@@ -1,15 +1,11 @@
-name: Benchmarks
+name: Benchmarks indexing
 
 on:
-  workflow_dispatch:
-    inputs:
-      dataset_name:
-        description: 'The name of the dataset used to benchmark (search_songs, search_wiki or indexing)'
-        required: false
-        default: 'search_songs'
+  schedule:
+    - cron: "30 0 * * FRI" # every friday at 00:30
 
 env:
-  BENCH_NAME: ${{ github.event.inputs.dataset_name }}
+  BENCH_NAME: "indexing"
 
 jobs:
   benchmarks:

--- a/.github/workflows/cron_benchmarks_indexing.yml
+++ b/.github/workflows/cron_benchmarks_indexing.yml
@@ -1,4 +1,4 @@
-name: Benchmarks indexing
+name: Benchmarks indexing (cron)
 
 on:
   schedule:

--- a/.github/workflows/cron_benchmarks_search_songs.yml
+++ b/.github/workflows/cron_benchmarks_search_songs.yml
@@ -1,15 +1,11 @@
-name: Benchmarks
+name: Benchmarks search songs
 
 on:
-  workflow_dispatch:
-    inputs:
-      dataset_name:
-        description: 'The name of the dataset used to benchmark (search_songs, search_wiki or indexing)'
-        required: false
-        default: 'search_songs'
+  schedule:
+    - cron: "30 08 * * FRI" # every friday at 08:30
 
 env:
-  BENCH_NAME: ${{ github.event.inputs.dataset_name }}
+  BENCH_NAME: "search_songs"
 
 jobs:
   benchmarks:

--- a/.github/workflows/cron_benchmarks_search_songs.yml
+++ b/.github/workflows/cron_benchmarks_search_songs.yml
@@ -1,4 +1,4 @@
-name: Benchmarks search songs
+name: Benchmarks search songs (cron)
 
 on:
   schedule:

--- a/.github/workflows/cron_benchmarks_search_wiki.yml
+++ b/.github/workflows/cron_benchmarks_search_wiki.yml
@@ -1,15 +1,11 @@
-name: Benchmarks
+name: Benchmarks search wikipedia articles
 
 on:
-  workflow_dispatch:
-    inputs:
-      dataset_name:
-        description: 'The name of the dataset used to benchmark (search_songs, search_wiki or indexing)'
-        required: false
-        default: 'search_songs'
+  schedule:
+    - cron: "30 16 * * FRI" # every friday at 16:30 (it’s snacky snack-time!)
 
 env:
-  BENCH_NAME: ${{ github.event.inputs.dataset_name }}
+  BENCH_NAME: "search_wiki"
 
 jobs:
   benchmarks:

--- a/.github/workflows/cron_benchmarks_search_wiki.yml
+++ b/.github/workflows/cron_benchmarks_search_wiki.yml
@@ -1,4 +1,4 @@
-name: Benchmarks search wikipedia articles
+name: Benchmarks search wikipedia articles (cron)
 
 on:
   schedule:


### PR DESCRIPTION
All the benchmarks run every Friday on the `main` branch.
To avoid having pending benchmarks everywhere, we execute one benchmark every 8 hours.
Then the results are uploaded as if it was a normal user-run benchmark.

This PR closes #314 and #321 