### PR TITLE
Introduce the reset_sortable_fields Settings method

### DIFF
--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -141,6 +141,10 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
         self.sortable_fields = Setting::Set(names);
     }
 
+    pub fn reset_sortable_fields(&mut self) {
+        self.sortable_fields = Setting::Reset;
+    }
+
     pub fn reset_criteria(&mut self) {
         self.criteria = Setting::Reset;
     }


### PR DESCRIPTION
I forgot to add the `reset_sortable_fields` method on the `Settings` builder, it is no big deal as the library user (like MeiliSearch) can always call `set_sortable_fields` with an empty list of fields, it is equivalent.