### PR TITLE
Get sortable_fields from index only if criteria present in query

### DIFF
--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -145,8 +145,8 @@ impl<'a> Search<'a> {
 
         // We check that we are allowed to use the sort criteria, we check
         // that they are declared in the sortable fields.
-        let sortable_fields = self.index.sortable_fields(self.rtxn)?;
         if let Some(sort_criteria) = &self.sort_criteria {
+            let sortable_fields = self.index.sortable_fields(self.rtxn)?;
             for asc_desc in sort_criteria {
                 let field = asc_desc.field();
                 if !sortable_fields.contains(field) {


### PR DESCRIPTION
Seems like we don't need to retrieve `sortable_fields` from the index if there's no any `sort_criteria` in the query.

Small 🤏  optimization opportunity out there.