### PR TITLE
Fix the returned `AscDesc` error

### DIFF
--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -156,7 +156,7 @@ impl FromStr for AscDesc {
         match text.rsplit_once(':') {
             Some((left, "asc")) => Ok(AscDesc::Asc(left.parse()?)),
             Some((left, "desc")) => Ok(AscDesc::Desc(left.parse()?)),
-            _ => Err(UserError::InvalidRankingRuleName { name: text.to_string() }),
+            _ => Err(UserError::InvalidAscDescSyntax { name: text.to_string() }),
         }
     }
 }


### PR DESCRIPTION
With my previous PR on the geosearch I erased the change I've introduced with my pre-previous PR about the new error type when we fail to parse the `AscDesc` type.

Sorry for that, here is the fix