### PR TITLE
Provide a sort error handler

### DIFF
--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -22,7 +22,9 @@ use meilisearch_tokenizer::{Analyzer, AnalyzerConfig};
 use milli::documents::DocumentBatchReader;
 use milli::update::UpdateIndexingStep::*;
 use milli::update::{IndexDocumentsMethod, Setting, UpdateBuilder};
-use milli::{obkv_to_json, CompressionType, FilterCondition, Index, MatchingWords, SearchResult};
+use milli::{
+    obkv_to_json, CompressionType, FilterCondition, Index, MatchingWords, SearchResult, SortError,
+};
 use once_cell::sync::OnceCell;
 use rayon::ThreadPool;
 use serde::{Deserialize, Serialize};
@@ -756,7 +758,7 @@ async fn main() -> anyhow::Result<()> {
             }
 
             if let Some(sort) = query.sort {
-                search.sort_criteria(vec![sort.parse().unwrap()]);
+                search.sort_criteria(vec![sort.parse().map_err(SortError::from).unwrap()]);
             }
 
             let SearchResult { matching_words, candidates, documents_ids } =

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -25,7 +25,7 @@ use fxhash::{FxHasher32, FxHasher64};
 pub use grenad::CompressionType;
 use serde_json::{Map, Value};
 
-pub use self::asc_desc::{AscDesc, AscDescError, Member};
+pub use self::asc_desc::{AscDesc, AscDescError, Member, SortError};
 pub use self::criterion::{default_criteria, Criterion, CriterionError};
 pub use self::error::{
     Error, FieldIdMapMissingEntry, InternalError, SerializationError, UserError,


### PR DESCRIPTION
This PR simplify the error handling of asc-desc rules for Meilisearch or any other wrapper by providing directly in milli a new error type called `SortError` that can be generated from an `AscDescError` and that can be automatically converted to a `UserError`.

Basically now, wherever you are in the code as a user or in milli you can parse an `AscDesc` syntax and depending on the context, cast it either as a `SortError` or a `CriterionError` in one line with improved error messages.