### PR TITLE
Fix Meilisearch 1714

### DIFF
--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -262,7 +262,7 @@ fn split_best_frequency(ctx: &impl Context, word: &str) -> heed::Result<Option<O
 /// and the provided word length.
 fn typos(word: String, authorize_typos: bool) -> QueryKind {
     if authorize_typos {
-        match word.len() {
+        match word.chars().count() {
             0..=4 => QueryKind::exact(word),
             5..=8 => QueryKind::tolerant(1, word),
             _ => QueryKind::tolerant(2, word),


### PR DESCRIPTION
The bug comes from the typo tolerance, to know how many typos are accepted we were counting bytes instead of characters in a word.
On Chinese Script characters, we were allowing  2 typos on 3 characters words.
We are now counting the number of char instead of counting bytes to assign the typo tolerance.

Related to [Meilisearch#1714](https://github.com/meilisearch/MeiliSearch/issues/1714)