### PR TITLE
Stop casting integer docids to string

### DIFF
--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -536,7 +536,7 @@ mod tests {
 
         // Check that this document is equal to the last one sent.
         let mut doc_iter = doc.iter();
-        assert_eq!(doc_iter.next(), Some((0, &br#""1""#[..])));
+        assert_eq!(doc_iter.next(), Some((0, &b"1"[..])));
         assert_eq!(doc_iter.next(), Some((1, &br#""benoit""#[..])));
         assert_eq!(doc_iter.next(), None);
         drop(rtxn);
@@ -562,9 +562,9 @@ mod tests {
 
         // Check that this document is equal to the last one sent.
         let mut doc_iter = doc.iter();
-        assert_eq!(doc_iter.next(), Some((0, &br#""1""#[..])));
+        assert_eq!(doc_iter.next(), Some((0, &b"1"[..])));
         assert_eq!(doc_iter.next(), Some((1, &br#""benoit""#[..])));
-        assert_eq!(doc_iter.next(), Some((2, &br#"25"#[..])));
+        assert_eq!(doc_iter.next(), Some((2, &b"25"[..])));
         assert_eq!(doc_iter.next(), None);
         drop(rtxn);
     }

--- a/milli/src/update/index_documents/transform.rs
+++ b/milli/src/update/index_documents/transform.rs
@@ -171,7 +171,6 @@ impl Transform<'_, '_> {
                             }
                         };
                         serde_json::to_writer(&mut external_id_buffer, &value).unwrap();
-                        *bytes = &external_id_buffer;
                         Cow::Owned(value)
                     }
                     None => {


### PR DESCRIPTION
When a docid is an integer, we stop casting it to a string, and thus we don't add `"` around it.