### PR TITLE
Hotfix meilisearch#1707

### DIFF
--- a/milli/src/search/criteria/attribute.rs
+++ b/milli/src/search/criteria/attribute.rs
@@ -193,7 +193,7 @@ impl<'t, 'q> WordLevelIterator<'t, 'q> {
     ) -> heed::Result<Option<Self>> {
         match ctx.word_position_last_level(&word, in_prefix_cache)? {
             Some(_) => {
-                // HOTFIX Meilisearch#1707: it is better to only iterate over the level 0.
+                // HOTFIX Meilisearch#1707: it is better to only iterate over level 0 for performances reasons.
                 let level = TreeLevel::min_value();
                 let interval_size = LEVEL_EXPONENTIATION_BASE.pow(Into::<u8>::into(level) as u32);
                 let inner =

--- a/milli/src/search/criteria/attribute.rs
+++ b/milli/src/search/criteria/attribute.rs
@@ -194,7 +194,6 @@ impl<'t, 'q> WordLevelIterator<'t, 'q> {
         match ctx.word_position_last_level(&word, in_prefix_cache)? {
             Some(_) => {
                 // HOTFIX Meilisearch#1707: it is better to only iterate over the level 0.
-                // A cleaner fix will be implemented soon.
                 let level = TreeLevel::min_value();
                 let interval_size = LEVEL_EXPONENTIATION_BASE.pow(Into::<u8>::into(level) as u32);
                 let inner =


### PR DESCRIPTION
This PR contains an ugly quick fix of [meilisearch#1707](https://github.com/meilisearch/MeiliSearch/issues/1707).

- remove comparison reverse on rank. Enhancing relevancy and performances
- iterate over level 0 only. Enhancing performances.

A better fix is in development.