### PR TITLE
Replace memmap with memmap2

### DIFF
--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -11,7 +11,7 @@ byte-unit = { version = "4.0.9", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.0"
 heed = { git = "https://github.com/Kerollmops/heed", tag = "v0.12.1" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
-memmap = "0.7.0"
+memmap2 = "0.5.0"
 milli = { path = "../milli" }
 once_cell = "1.5.2"
 rayon = "1.5.0"

--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -860,7 +860,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         let file = file.into_std().await;
-        let mmap = unsafe { memmap::Mmap::map(&file).expect("can't map file") };
+        let mmap = unsafe { memmap2::Mmap::map(&file).expect("can't map file") };
 
         let method = match update_method.as_deref() {
             Some("replace") => String::from("replace"),

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -23,7 +23,7 @@ human_format = "1.0.3"
 levenshtein_automata = { version = "0.2.0", features = ["fst_automaton"] }
 linked-hash-map = "0.5.4"
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
-memmap = "0.7.0"
+memmap2 = "0.5.0"
 obkv = "0.2.0"
 once_cell = "1.5.2"
 ordered-float = "2.1.1"

--- a/milli/src/update/index_documents/helpers/clonable_mmap.rs
+++ b/milli/src/update/index_documents/helpers/clonable_mmap.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use memmap::Mmap;
+use memmap2::Mmap;
 
 /// Wrapper around Mmap allowing to virtualy clone grenad-chunks
 /// in a parallel process like the indexing.

--- a/milli/src/update/index_documents/helpers/grenad_helpers.rs
+++ b/milli/src/update/index_documents/helpers/grenad_helpers.rs
@@ -70,7 +70,7 @@ pub unsafe fn into_clonable_grenad(
     reader: grenad::Reader<File>,
 ) -> Result<grenad::Reader<CursorClonableMmap>> {
     let file = reader.into_inner();
-    let mmap = memmap::Mmap::map(&file)?;
+    let mmap = memmap2::Mmap::map(&file)?;
     let cursor = io::Cursor::new(ClonableMmap::from(mmap));
     let reader = grenad::Reader::new(cursor)?;
     Ok(reader)


### PR DESCRIPTION
[memmap is unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0077.html) and needs replacing. memmap2 is a drop-in replacement fork that's well maintained. Note that the version numbers got reset on fork, hence the lower values.