### PR TITLE
Fix obkv document

### DIFF
--- a/milli/src/documents/mod.rs
+++ b/milli/src/documents/mod.rs
@@ -230,4 +230,12 @@ mod test {
         let nested: Value = serde_json::from_slice(doc.get(0).unwrap()).unwrap();
         assert_eq!(nested, json!({ "toto": ["hello"] }));
     }
+
+    #[test]
+    fn out_of_order_fields() {
+        let _documents = documents!([
+            {"id": 1,"b": 0},
+            {"id": 2,"a": 0,"b": 0},
+        ]);
+    }
 }

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1134,7 +1134,6 @@ mod tests {
             "release_date": 819676800
           }
         ]);
-
         let builder = IndexDocuments::new(&mut wtxn, &index, 1);
         builder.execute(content, |_, _| ()).unwrap();
         wtxn.commit().unwrap();


### PR DESCRIPTION
When serializing a document, the serializer resolved the field_id of the current field and immediately added it to the obkv document under construction. The issue with that is that obkv expects the fields to be inserted in order, and when a document with out of order fields was added, obkv failed to insert the field.

The current fix first resolves each field_id, and adds all the fields to a temporary `BTreeMap`, until `end` is called on the map serializer, where all the fields are added to the obkv at once, and in order.
