### PR TITLE
remove update_id in UpdateBuilder

### DIFF
--- a/benchmarks/benches/indexing.rs
+++ b/benchmarks/benches/indexing.rs
@@ -39,7 +39,7 @@ fn indexing_songs_default(c: &mut Criterion) {
             move || {
                 let index = setup_index();
 
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -61,17 +61,17 @@ fn indexing_songs_default(c: &mut Criterion) {
                         .map(|s| s.to_string())
                         .collect();
                 builder.set_filterable_fields(faceted_fields);
-                builder.execute(|_, _| ()).unwrap();
+                builder.execute(|_| ()).unwrap();
                 wtxn.commit().unwrap();
                 index
             },
             move |index| {
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let builder = update_builder.index_documents(&mut wtxn, &index);
 
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS, "csv");
-                builder.execute(documents, |_, _| ()).unwrap();
+                builder.execute(documents, |_| ()).unwrap();
                 wtxn.commit().unwrap();
 
                 index.prepare_for_closing().wait();
@@ -88,7 +88,7 @@ fn indexing_songs_without_faceted_numbers(c: &mut Criterion) {
             move || {
                 let index = setup_index();
 
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -107,17 +107,17 @@ fn indexing_songs_without_faceted_numbers(c: &mut Criterion) {
                 let faceted_fields =
                     ["genre", "country", "artist"].iter().map(|s| s.to_string()).collect();
                 builder.set_filterable_fields(faceted_fields);
-                builder.execute(|_, _| ()).unwrap();
+                builder.execute(|_| ()).unwrap();
                 wtxn.commit().unwrap();
                 index
             },
             move |index| {
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let builder = update_builder.index_documents(&mut wtxn, &index);
 
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS, "csv");
-                builder.execute(documents, |_, _| ()).unwrap();
+                builder.execute(documents, |_| ()).unwrap();
                 wtxn.commit().unwrap();
 
                 index.prepare_for_closing().wait();
@@ -134,7 +134,7 @@ fn indexing_songs_without_faceted_fields(c: &mut Criterion) {
             move || {
                 let index = setup_index();
 
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -149,17 +149,17 @@ fn indexing_songs_without_faceted_fields(c: &mut Criterion) {
                 let searchable_fields =
                     ["title", "album", "artist"].iter().map(|s| s.to_string()).collect();
                 builder.set_searchable_fields(searchable_fields);
-                builder.execute(|_, _| ()).unwrap();
+                builder.execute(|_| ()).unwrap();
                 wtxn.commit().unwrap();
                 index
             },
             move |index| {
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let builder = update_builder.index_documents(&mut wtxn, &index);
 
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS, "csv");
-                builder.execute(documents, |_, _| ()).unwrap();
+                builder.execute(documents, |_| ()).unwrap();
                 wtxn.commit().unwrap();
 
                 index.prepare_for_closing().wait();
@@ -176,7 +176,7 @@ fn indexing_wiki(c: &mut Criterion) {
             move || {
                 let index = setup_index();
 
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -190,18 +190,18 @@ fn indexing_wiki(c: &mut Criterion) {
 
                 // there is NO faceted fields at all
 
-                builder.execute(|_, _| ()).unwrap();
+                builder.execute(|_| ()).unwrap();
                 wtxn.commit().unwrap();
                 index
             },
             move |index| {
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.index_documents(&mut wtxn, &index);
                 builder.enable_autogenerate_docids();
 
                 let documents = utils::documents_from(datasets_paths::SMOL_WIKI_ARTICLES, "csv");
-                builder.execute(documents, |_, _| ()).unwrap();
+                builder.execute(documents, |_| ()).unwrap();
                 wtxn.commit().unwrap();
 
                 index.prepare_for_closing().wait();
@@ -218,7 +218,7 @@ fn indexing_movies_default(c: &mut Criterion) {
             move || {
                 let index = setup_index();
 
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -237,17 +237,17 @@ fn indexing_movies_default(c: &mut Criterion) {
                     ["released_date", "genres"].iter().map(|s| s.to_string()).collect();
                 builder.set_filterable_fields(faceted_fields);
 
-                builder.execute(|_, _| ()).unwrap();
+                builder.execute(|_| ()).unwrap();
                 wtxn.commit().unwrap();
                 index
             },
             move |index| {
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let builder = update_builder.index_documents(&mut wtxn, &index);
 
                 let documents = utils::documents_from(datasets_paths::MOVIES, "json");
-                builder.execute(documents, |_, _| ()).unwrap();
+                builder.execute(documents, |_| ()).unwrap();
                 wtxn.commit().unwrap();
 
                 index.prepare_for_closing().wait();
@@ -264,7 +264,7 @@ fn indexing_geo(c: &mut Criterion) {
             move || {
                 let index = setup_index();
 
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -288,17 +288,17 @@ fn indexing_geo(c: &mut Criterion) {
                     ["_geo", "population", "elevation"].iter().map(|s| s.to_string()).collect();
                 builder.set_sortable_fields(sortable_fields);
 
-                builder.execute(|_, _| ()).unwrap();
+                builder.execute(|_| ()).unwrap();
                 wtxn.commit().unwrap();
                 index
             },
             move |index| {
-                let update_builder = UpdateBuilder::new(0);
+                let update_builder = UpdateBuilder::new();
                 let mut wtxn = index.write_txn().unwrap();
                 let builder = update_builder.index_documents(&mut wtxn, &index);
 
                 let documents = utils::documents_from(datasets_paths::SMOL_ALL_COUNTRIES, "jsonl");
-                builder.execute(documents, |_, _| ()).unwrap();
+                builder.execute(documents, |_| ()).unwrap();
 
                 wtxn.commit().unwrap();
 

--- a/benchmarks/benches/utils.rs
+++ b/benchmarks/benches/utils.rs
@@ -65,7 +65,7 @@ pub fn base_setup(conf: &Conf) -> Index {
     options.max_readers(10);
     let index = Index::new(options, conf.database_name).unwrap();
 
-    let update_builder = UpdateBuilder::new(0);
+    let update_builder = UpdateBuilder::new();
     let mut wtxn = index.write_txn().unwrap();
     let mut builder = update_builder.settings(&mut wtxn, &index);
 
@@ -84,10 +84,10 @@ pub fn base_setup(conf: &Conf) -> Index {
 
     (conf.configure)(&mut builder);
 
-    builder.execute(|_, _| ()).unwrap();
+    builder.execute(|_| ()).unwrap();
     wtxn.commit().unwrap();
 
-    let update_builder = UpdateBuilder::new(0);
+    let update_builder = UpdateBuilder::new();
     let mut wtxn = index.write_txn().unwrap();
     let mut builder = update_builder.index_documents(&mut wtxn, &index);
     if let None = conf.primary_key {
@@ -96,7 +96,7 @@ pub fn base_setup(conf: &Conf) -> Index {
     let documents = documents_from(conf.dataset, conf.dataset_format);
 
     builder.index_documents_method(IndexDocumentsMethod::ReplaceDocuments);
-    builder.execute(documents, |_, _| ()).unwrap();
+    builder.execute(documents, |_| ()).unwrap();
     wtxn.commit().unwrap();
 
     index

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,7 @@ impl DocumentAddition {
         println!("Adding {} documents to the index.", reader.len());
 
         let mut txn = index.env.write_txn()?;
-        let mut addition = milli::update::IndexDocuments::new(&mut txn, &index, 0);
+        let mut addition = milli::update::IndexDocuments::new(&mut txn, &index);
 
         if self.update_documents {
             addition.index_documents_method(milli::update::IndexDocumentsMethod::UpdateDocuments);
@@ -146,7 +146,7 @@ impl DocumentAddition {
             progesses.join().unwrap();
         });
 
-        let result = addition.execute(reader, |step, _| indexing_callback(step, &bars))?;
+        let result = addition.execute(reader, |step| indexing_callback(step, &bars))?;
 
         txn.commit()?;
 
@@ -292,7 +292,7 @@ impl SettingsUpdate {
     fn perform(&self, index: milli::Index) -> Result<()> {
         let mut txn = index.env.write_txn()?;
 
-        let mut update = milli::update::Settings::new(&mut txn, &index, 0);
+        let mut update = milli::update::Settings::new(&mut txn, &index);
         update.log_every_n(100);
 
         if let Some(ref filterable_attributes) = self.filterable_attributes {
@@ -315,7 +315,7 @@ impl SettingsUpdate {
             progesses.join().unwrap();
         });
 
-        update.execute(|step, _| indexing_callback(step, &bars))?;
+        update.execute(|step| indexing_callback(step, &bars))?;
 
         txn.commit()?;
         Ok(())

--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -343,7 +343,7 @@ async fn main() -> anyhow::Result<()> {
         // the type hint is necessary: https://github.com/rust-lang/rust/issues/32600
         move |update_id, meta, content: &_| {
             // We prepare the update by using the update builder.
-            let mut update_builder = UpdateBuilder::new(update_id);
+            let mut update_builder = UpdateBuilder::new();
             if let Some(max_nb_chunks) = indexer_opt_cloned.max_nb_chunks {
                 update_builder.max_nb_chunks(max_nb_chunks);
             }
@@ -393,7 +393,7 @@ async fn main() -> anyhow::Result<()> {
 
                         let documents = DocumentBatchReader::from_reader(Cursor::new(documents))?;
 
-                        let result = builder.execute(documents, |indexing_step, update_id| {
+                        let result = builder.execute(documents, |indexing_step| {
                             let (current, total) = match indexing_step {
                                 RemapDocumentAddition { documents_seen } => (documents_seen, None),
                                 ComputeIdsAndMergeDocuments { documents_seen, total_documents } => {
@@ -494,7 +494,7 @@ async fn main() -> anyhow::Result<()> {
                             Setting::NotSet => (),
                         }
 
-                        let result = builder.execute(|indexing_step, update_id| {
+                        let result = builder.execute(|indexing_step| {
                             let (current, total) = match indexing_step {
                                 RemapDocumentAddition { documents_seen } => (documents_seen, None),
                                 ComputeIdsAndMergeDocuments { documents_seen, total_documents } => {

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -908,8 +908,8 @@ pub(crate) mod tests {
             { "id": 2, "name": "bob", "age": 20 },
             { "id": 2, "name": "bob", "age": 20 }
         ]);
-        let builder = IndexDocuments::new(&mut wtxn, &index, 0);
-        builder.execute(content, |_, _| ()).unwrap();
+        let builder = IndexDocuments::new(&mut wtxn, &index);
+        builder.execute(content, |_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
@@ -927,13 +927,13 @@ pub(crate) mod tests {
         // we add all the documents a second time. we are supposed to get the same
         // field_distribution in the end
         let mut wtxn = index.write_txn().unwrap();
-        let builder = IndexDocuments::new(&mut wtxn, &index, 0);
+        let builder = IndexDocuments::new(&mut wtxn, &index);
         let content = documents!([
             { "id": 1, "name": "kevin" },
             { "id": 2, "name": "bob", "age": 20 },
             { "id": 2, "name": "bob", "age": 20 }
         ]);
-        builder.execute(content, |_, _| ()).unwrap();
+        builder.execute(content, |_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
@@ -955,8 +955,8 @@ pub(crate) mod tests {
         ]);
 
         let mut wtxn = index.write_txn().unwrap();
-        let builder = IndexDocuments::new(&mut wtxn, &index, 0);
-        builder.execute(content, |_, _| ()).unwrap();
+        let builder = IndexDocuments::new(&mut wtxn, &index);
+        builder.execute(content, |_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();

--- a/milli/src/search/distinct/mod.rs
+++ b/milli/src/search/distinct/mod.rs
@@ -84,19 +84,19 @@ mod test {
         let mut txn = index.write_txn().unwrap();
 
         // set distinct and faceted attributes for the index.
-        let builder = UpdateBuilder::new(0);
+        let builder = UpdateBuilder::new();
         let mut update = builder.settings(&mut txn, &index);
         update.set_distinct_field(distinct.to_string());
-        update.execute(|_, _| ()).unwrap();
+        update.execute(|_| ()).unwrap();
 
         // add documents to the index
-        let builder = UpdateBuilder::new(1);
+        let builder = UpdateBuilder::new();
         let mut addition = builder.index_documents(&mut txn, &index);
 
         addition.index_documents_method(IndexDocumentsMethod::ReplaceDocuments);
         let reader =
             crate::documents::DocumentBatchReader::from_reader(Cursor::new(&*JSON)).unwrap();
-        addition.execute(reader, |_, _| ()).unwrap();
+        addition.execute(reader, |_| ()).unwrap();
 
         let fields_map = index.fields_ids_map(&txn).unwrap();
         let fid = fields_map.id(&distinct).unwrap();

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -512,10 +512,10 @@ mod tests {
 
         // Set the filterable fields to be the channel.
         let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index, 0);
+        let mut builder = Settings::new(&mut wtxn, &index);
         builder.set_searchable_fields(vec![S("title")]);
         builder.set_filterable_fields(hashset! { S("title") });
-        builder.execute(|_, _| ()).unwrap();
+        builder.execute(|_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
@@ -542,10 +542,10 @@ mod tests {
 
         // Set the filterable fields to be the channel.
         let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index, 0);
+        let mut builder = Settings::new(&mut wtxn, &index);
         builder.set_searchable_fields(vec![S("_geo"), S("price")]); // to keep the fields order
         builder.set_filterable_fields(hashset! { S("_geo"), S("price") });
-        builder.execute(|_, _| ()).unwrap();
+        builder.execute(|_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();

--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -6,16 +6,11 @@ use crate::{ExternalDocumentsIds, FieldDistribution, Index, Result};
 pub struct ClearDocuments<'t, 'u, 'i> {
     wtxn: &'t mut heed::RwTxn<'i, 'u>,
     index: &'i Index,
-    _update_id: u64,
 }
 
 impl<'t, 'u, 'i> ClearDocuments<'t, 'u, 'i> {
-    pub fn new(
-        wtxn: &'t mut heed::RwTxn<'i, 'u>,
-        index: &'i Index,
-        update_id: u64,
-    ) -> ClearDocuments<'t, 'u, 'i> {
-        ClearDocuments { wtxn, index, _update_id: update_id }
+    pub fn new(wtxn: &'t mut heed::RwTxn<'i, 'u>, index: &'i Index) -> ClearDocuments<'t, 'u, 'i> {
+        ClearDocuments { wtxn, index }
     }
 
     pub fn execute(self) -> Result<u64> {
@@ -97,10 +92,10 @@ mod tests {
             { "id": 1, "name": "kevina" },
             { "id": 2, "name": "benoit", "country": "France", "_geo": { "lng": 42, "lat": 35 } }
         ]);
-        IndexDocuments::new(&mut wtxn, &index, 0).execute(content, |_, _| ()).unwrap();
+        IndexDocuments::new(&mut wtxn, &index).execute(content, |_| ()).unwrap();
 
         // Clear all documents from the database.
-        let builder = ClearDocuments::new(&mut wtxn, &index, 1);
+        let builder = ClearDocuments::new(&mut wtxn, &index);
         assert_eq!(builder.execute().unwrap(), 3);
 
         wtxn.commit().unwrap();

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -23,7 +23,6 @@ pub struct DeleteDocuments<'t, 'u, 'i> {
     index: &'i Index,
     external_documents_ids: ExternalDocumentsIds<'static>,
     documents_ids: RoaringBitmap,
-    update_id: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -36,7 +35,6 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
     pub fn new(
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
-        update_id: u64,
     ) -> Result<DeleteDocuments<'t, 'u, 'i>> {
         let external_documents_ids = index.external_documents_ids(wtxn)?.into_static();
 
@@ -45,7 +43,6 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
             index,
             external_documents_ids,
             documents_ids: RoaringBitmap::new(),
-            update_id,
         })
     }
 
@@ -85,8 +82,7 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
         // We can execute a ClearDocuments operation when the number of documents
         // to delete is exactly the number of documents in the database.
         if current_documents_ids_len == self.documents_ids.len() {
-            let remaining_documents =
-                ClearDocuments::new(self.wtxn, self.index, self.update_id).execute()?;
+            let remaining_documents = ClearDocuments::new(self.wtxn, self.index).execute()?;
             return Ok(DocumentDeletionResult {
                 deleted_documents: current_documents_ids_len,
                 remaining_documents,
@@ -600,11 +596,11 @@ mod tests {
             { "id": 1, "name": "kevina", "array": ["I", "am", "fine"] },
             { "id": 2, "name": "benoit", "array_of_object": [{ "wow": "amazing" }] }
         ]);
-        let builder = IndexDocuments::new(&mut wtxn, &index, 0);
-        builder.execute(content, |_, _| ()).unwrap();
+        let builder = IndexDocuments::new(&mut wtxn, &index);
+        builder.execute(content, |_| ()).unwrap();
 
         // delete those documents, ids are synchronous therefore 0, 1, and 2.
-        let mut builder = DeleteDocuments::new(&mut wtxn, &index, 1).unwrap();
+        let mut builder = DeleteDocuments::new(&mut wtxn, &index).unwrap();
         builder.delete_document(0);
         builder.delete_document(1);
         builder.delete_document(2);
@@ -630,11 +626,11 @@ mod tests {
             { "mysuperid": 1, "name": "kevina" },
             { "mysuperid": 2, "name": "benoit" }
         ]);
-        let builder = IndexDocuments::new(&mut wtxn, &index, 0);
-        builder.execute(content, |_, _| ()).unwrap();
+        let builder = IndexDocuments::new(&mut wtxn, &index);
+        builder.execute(content, |_| ()).unwrap();
 
         // Delete not all of the documents but some of them.
-        let mut builder = DeleteDocuments::new(&mut wtxn, &index, 1).unwrap();
+        let mut builder = DeleteDocuments::new(&mut wtxn, &index).unwrap();
         builder.delete_external_id("0");
         builder.delete_external_id("1");
         builder.execute().unwrap();
@@ -650,10 +646,10 @@ mod tests {
         let index = Index::new(options, &path).unwrap();
 
         let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index, 0);
+        let mut builder = Settings::new(&mut wtxn, &index);
         builder.set_primary_key(S("docid"));
         builder.set_filterable_fields(hashset! { S("label") });
-        builder.execute(|_, _| ()).unwrap();
+        builder.execute(|_| ()).unwrap();
 
         let content = documents!([
             {"docid":"1_4","label":"sign"},
@@ -677,11 +673,11 @@ mod tests {
             {"docid":"1_68","label":"design"},
             {"docid":"1_69","label":"geometry"}
         ]);
-        let builder = IndexDocuments::new(&mut wtxn, &index, 0);
-        builder.execute(content, |_, _| ()).unwrap();
+        let builder = IndexDocuments::new(&mut wtxn, &index);
+        builder.execute(content, |_| ()).unwrap();
 
         // Delete not all of the documents but some of them.
-        let mut builder = DeleteDocuments::new(&mut wtxn, &index, 1).unwrap();
+        let mut builder = DeleteDocuments::new(&mut wtxn, &index).unwrap();
         builder.delete_external_id("1_4");
         builder.execute().unwrap();
 
@@ -700,11 +696,11 @@ mod tests {
         let index = Index::new(options, &path).unwrap();
 
         let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index, 0);
+        let mut builder = Settings::new(&mut wtxn, &index);
         builder.set_primary_key(S("id"));
         builder.set_filterable_fields(hashset!(S("_geo")));
         builder.set_sortable_fields(hashset!(S("_geo")));
-        builder.execute(|_, _| ()).unwrap();
+        builder.execute(|_| ()).unwrap();
 
         let content = documents!([
             {"id":"1","city":"Lille",             "_geo": { "lat": 50.629973371633746, "lng": 3.0569447399419570 } },
@@ -730,7 +726,7 @@ mod tests {
         ]);
         let external_ids_to_delete = ["5", "6", "7", "12", "17", "19"];
 
-        IndexDocuments::new(&mut wtxn, &index, 0).execute(content, |_, _| ()).unwrap();
+        IndexDocuments::new(&mut wtxn, &index).execute(content, |_| ()).unwrap();
 
         let external_document_ids = index.external_documents_ids(&wtxn).unwrap();
         let ids_to_delete: Vec<u32> = external_ids_to_delete
@@ -739,7 +735,7 @@ mod tests {
             .collect();
 
         // Delete some documents.
-        let mut builder = DeleteDocuments::new(&mut wtxn, &index, 1).unwrap();
+        let mut builder = DeleteDocuments::new(&mut wtxn, &index).unwrap();
         external_ids_to_delete.iter().for_each(|id| drop(builder.delete_external_id(id)));
         builder.execute().unwrap();
 

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -27,15 +27,10 @@ pub struct Facets<'t, 'u, 'i> {
     pub(crate) chunk_compression_level: Option<u32>,
     level_group_size: NonZeroUsize,
     min_level_size: NonZeroUsize,
-    _update_id: u64,
 }
 
 impl<'t, 'u, 'i> Facets<'t, 'u, 'i> {
-    pub fn new(
-        wtxn: &'t mut heed::RwTxn<'i, 'u>,
-        index: &'i Index,
-        update_id: u64,
-    ) -> Facets<'t, 'u, 'i> {
+    pub fn new(wtxn: &'t mut heed::RwTxn<'i, 'u>, index: &'i Index) -> Facets<'t, 'u, 'i> {
         Facets {
             wtxn,
             index,
@@ -43,7 +38,6 @@ impl<'t, 'u, 'i> Facets<'t, 'u, 'i> {
             chunk_compression_level: None,
             level_group_size: NonZeroUsize::new(4).unwrap(),
             min_level_size: NonZeroUsize::new(5).unwrap(),
-            _update_id: update_id,
         }
     }
 

--- a/milli/src/update/update_builder.rs
+++ b/milli/src/update/update_builder.rs
@@ -13,11 +13,10 @@ pub struct UpdateBuilder<'a> {
     pub(crate) chunk_compression_level: Option<u32>,
     pub(crate) thread_pool: Option<&'a ThreadPool>,
     pub(crate) max_positions_per_attributes: Option<u32>,
-    pub(crate) update_id: u64,
 }
 
 impl<'a> UpdateBuilder<'a> {
-    pub fn new(update_id: u64) -> UpdateBuilder<'a> {
+    pub fn new() -> UpdateBuilder<'a> {
         UpdateBuilder {
             log_every_n: None,
             max_nb_chunks: None,
@@ -27,7 +26,6 @@ impl<'a> UpdateBuilder<'a> {
             chunk_compression_level: None,
             thread_pool: None,
             max_positions_per_attributes: None,
-            update_id,
         }
     }
 
@@ -68,7 +66,7 @@ impl<'a> UpdateBuilder<'a> {
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
     ) -> ClearDocuments<'t, 'u, 'i> {
-        ClearDocuments::new(wtxn, index, self.update_id)
+        ClearDocuments::new(wtxn, index)
     }
 
     pub fn delete_documents<'t, 'u, 'i>(
@@ -76,7 +74,7 @@ impl<'a> UpdateBuilder<'a> {
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
     ) -> Result<DeleteDocuments<'t, 'u, 'i>> {
-        DeleteDocuments::new(wtxn, index, self.update_id)
+        DeleteDocuments::new(wtxn, index)
     }
 
     pub fn index_documents<'t, 'u, 'i>(
@@ -84,7 +82,7 @@ impl<'a> UpdateBuilder<'a> {
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
     ) -> IndexDocuments<'t, 'u, 'i, 'a> {
-        let mut builder = IndexDocuments::new(wtxn, index, self.update_id);
+        let mut builder = IndexDocuments::new(wtxn, index);
 
         builder.log_every_n = self.log_every_n;
         builder.max_nb_chunks = self.max_nb_chunks;
@@ -103,7 +101,7 @@ impl<'a> UpdateBuilder<'a> {
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
     ) -> Settings<'a, 't, 'u, 'i> {
-        let mut builder = Settings::new(wtxn, index, self.update_id);
+        let mut builder = Settings::new(wtxn, index);
 
         builder.log_every_n = self.log_every_n;
         builder.max_nb_chunks = self.max_nb_chunks;
@@ -122,7 +120,7 @@ impl<'a> UpdateBuilder<'a> {
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
     ) -> Facets<'t, 'u, 'i> {
-        let mut builder = Facets::new(wtxn, index, self.update_id);
+        let mut builder = Facets::new(wtxn, index);
 
         builder.chunk_compression_type = self.chunk_compression_type;
         builder.chunk_compression_level = self.chunk_compression_level;

--- a/milli/src/update/words_prefixes_fst.rs
+++ b/milli/src/update/words_prefixes_fst.rs
@@ -10,22 +10,14 @@ pub struct WordsPrefixesFst<'t, 'u, 'i> {
     index: &'i Index,
     threshold: u32,
     max_prefix_length: usize,
-    _update_id: u64,
 }
 
 impl<'t, 'u, 'i> WordsPrefixesFst<'t, 'u, 'i> {
     pub fn new(
         wtxn: &'t mut heed::RwTxn<'i, 'u>,
         index: &'i Index,
-        update_id: u64,
     ) -> WordsPrefixesFst<'t, 'u, 'i> {
-        WordsPrefixesFst {
-            wtxn,
-            index,
-            threshold: 100,
-            max_prefix_length: 4,
-            _update_id: update_id,
-        }
+        WordsPrefixesFst { wtxn, index, threshold: 100, max_prefix_length: 4 }
     }
 
     /// Set the number of words required to make a prefix be part of the words prefixes

--- a/milli/tests/search/distinct.rs
+++ b/milli/tests/search/distinct.rs
@@ -16,9 +16,9 @@ macro_rules! test_distinct {
 
             // update distinct attribute
             let mut wtxn = index.write_txn().unwrap();
-            let mut builder = Settings::new(&mut wtxn, &index, 0);
+            let mut builder = Settings::new(&mut wtxn, &index);
             builder.set_distinct_field(S(stringify!($distinct)));
-            builder.execute(|_, _| ()).unwrap();
+            builder.execute(|_| ()).unwrap();
             wtxn.commit().unwrap();
 
             let rtxn = index.read_txn().unwrap();

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -32,7 +32,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
 
     let mut wtxn = index.write_txn().unwrap();
 
-    let mut builder = Settings::new(&mut wtxn, &index, 0);
+    let mut builder = Settings::new(&mut wtxn, &index);
 
     let criteria = criteria.iter().map(|c| c.to_string()).collect();
     builder.set_criteria(criteria);
@@ -51,10 +51,10 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
         S("america") => vec![S("the united states")],
     });
     builder.set_searchable_fields(vec![S("title"), S("description")]);
-    builder.execute(|_, _| ()).unwrap();
+    builder.execute(|_| ()).unwrap();
 
     // index documents
-    let mut builder = UpdateBuilder::new(0);
+    let mut builder = UpdateBuilder::new();
     builder.max_memory(10 * 1024 * 1024); // 10MiB
     let mut builder = builder.index_documents(&mut wtxn, &index);
     builder.enable_autogenerate_docids();
@@ -73,7 +73,7 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
 
     // index documents
     let content = DocumentBatchReader::from_reader(cursor).unwrap();
-    builder.execute(content, |_, _| ()).unwrap();
+    builder.execute(content, |_| ()).unwrap();
 
     wtxn.commit().unwrap();
 

--- a/milli/tests/search/query_criteria.rs
+++ b/milli/tests/search/query_criteria.rs
@@ -341,9 +341,9 @@ fn criteria_mixup() {
         eprintln!("Testing with criteria order: {:?}", &criteria);
         //update criteria
         let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index, 0);
+        let mut builder = Settings::new(&mut wtxn, &index);
         builder.set_criteria(criteria.iter().map(ToString::to_string).collect());
-        builder.execute(|_, _| ()).unwrap();
+        builder.execute(|_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let mut rtxn = index.read_txn().unwrap();
@@ -376,16 +376,16 @@ fn criteria_ascdesc() {
 
     let mut wtxn = index.write_txn().unwrap();
 
-    let mut builder = Settings::new(&mut wtxn, &index, 0);
+    let mut builder = Settings::new(&mut wtxn, &index);
 
     builder.set_sortable_fields(hashset! {
         S("name"),
         S("age"),
     });
-    builder.execute(|_, _| ()).unwrap();
+    builder.execute(|_| ()).unwrap();
 
     // index documents
-    let mut builder = UpdateBuilder::new(0);
+    let mut builder = UpdateBuilder::new();
     builder.max_memory(10 * 1024 * 1024); // 10MiB
     let mut builder = builder.index_documents(&mut wtxn, &index);
     builder.enable_autogenerate_docids();
@@ -419,7 +419,7 @@ fn criteria_ascdesc() {
 
     let reader = DocumentBatchReader::from_reader(cursor).unwrap();
 
-    builder.execute(reader, |_, _| ()).unwrap();
+    builder.execute(reader, |_| ()).unwrap();
 
     wtxn.commit().unwrap();
 
@@ -430,9 +430,9 @@ fn criteria_ascdesc() {
         eprintln!("Testing with criterion: {:?}", &criterion);
 
         let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index, 0);
+        let mut builder = Settings::new(&mut wtxn, &index);
         builder.set_criteria(vec![criterion.to_string()]);
-        builder.execute(|_, _| ()).unwrap();
+        builder.execute(|_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let mut rtxn = index.read_txn().unwrap();


### PR DESCRIPTION
Removing the `update_id` from `UpdateBuidler`, since it serves no purpose. I had introduced it when working in HA some time ago, but I think there are better ways to do it now, so it can be removed an stop being in our way.