### PR TITLE
Update tokenizer v0.2.6

### DIFF
--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.38"
 byte-unit = { version = "4.0.9", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.0"
 heed = { git = "https://github.com/Kerollmops/heed", tag = "v0.12.1" }
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.6" }
 memmap2 = "0.5.0"
 milli = { path = "../milli" }
 once_cell = "1.5.2"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -22,7 +22,7 @@ heed = { git = "https://github.com/Kerollmops/heed", tag = "v0.12.1", default-fe
 human_format = "1.0.3"
 levenshtein_automata = { version = "0.2.0", features = ["fst_automaton"] }
 linked-hash-map = "0.5.4"
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.5" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.6" }
 memmap2 = "0.5.0"
 obkv = "0.2.0"
 once_cell = "1.5.2"

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -20,6 +20,7 @@ use std::hash::BuildHasherDefault;
 pub use filter_parser::{Condition, FilterCondition};
 use fxhash::{FxHasher32, FxHasher64};
 pub use grenad::CompressionType;
+pub use meilisearch_tokenizer as tokenizer;
 use serde_json::{Map, Value};
 
 pub use self::asc_desc::{AscDesc, AscDescError, Member, SortError};


### PR DESCRIPTION
- Update tokenizer v0.2.6
- Export tokenizer from milli in order to use the same version between milli and Meilisearch
