### PR TITLE
change visibility of DocumentDeletionResult

### DIFF
--- a/milli/src/update/mod.rs
+++ b/milli/src/update/mod.rs
@@ -1,6 +1,6 @@
 pub use self::available_documents_ids::AvailableDocumentsIds;
 pub use self::clear_documents::ClearDocuments;
-pub use self::delete_documents::DeleteDocuments;
+pub use self::delete_documents::{DeleteDocuments, DocumentDeletionResult};
 pub use self::facets::Facets;
 pub use self::index_documents::{DocumentAdditionResult, IndexDocuments, IndexDocumentsMethod};
 pub use self::settings::{Setting, Settings};


### PR DESCRIPTION
Change the visibility of `DocumentDeletionResult`, so its fields can be accesses from outside milli.
