### PR TITLE
 fix word pair proximity indexing

### DIFF
--- a/milli/src/update/index_documents/extract/extract_word_pair_proximity_docids.rs
+++ b/milli/src/update/index_documents/extract/extract_word_pair_proximity_docids.rs
@@ -53,7 +53,9 @@ pub fn extract_word_pair_proximity_docids<R: io::Read>(
         }
 
         let word = word.to_string();
-        let mut iter = read_u32_ne_bytes(value).collect::<Vec<_>>().into_iter();
+        let mut positions: Vec<_> = read_u32_ne_bytes(value).collect();
+        positions.sort_unstable();
+        let mut iter = positions.into_iter();
         if let Some(position) = iter.next() {
             document_word_positions_heap.push(PeekedWordPosition { word, position, iter });
         }


### PR DESCRIPTION
# Pull Request

Sort positions before iterating over them during word pair proximity extraction.

fixes [Meilisearch#1913](https://github.com/meilisearch/MeiliSearch/issues/1913)