### PR TITLE
Introduce the depth method on FilterCondition

### DIFF
--- a/filter-parser/src/lib.rs
+++ b/filter-parser/src/lib.rs
@@ -118,10 +118,12 @@ impl<'a> FilterCondition<'a> {
         match self {
             FilterCondition::Condition { fid, .. } if depth == 0 => Some(fid),
             FilterCondition::Or(left, right) => {
-                left.token_at_depth(depth - 1).or_else(|| right.token_at_depth(depth - 1))
+                let depth = depth.saturating_sub(1);
+                right.token_at_depth(depth).or_else(|| left.token_at_depth(depth))
             }
             FilterCondition::And(left, right) => {
-                left.token_at_depth(depth - 1).or_else(|| right.token_at_depth(depth - 1))
+                let depth = depth.saturating_sub(1);
+                right.token_at_depth(depth).or_else(|| left.token_at_depth(depth))
             }
             FilterCondition::GeoLowerThan { point: [point, _], .. } if depth == 0 => Some(point),
             FilterCondition::GeoGreaterThan { point: [point, _], .. } if depth == 0 => Some(point),

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -16,7 +16,7 @@ use crate::heed_codec::facet::{
 use crate::{distance_between_two_points, CboRoaringBitmapCodec, FieldId, Index, Result};
 
 /// The maximum number of filters the filter AST can process.
-const MAX_FILTER_DEPTH: usize = 1000;
+const MAX_FILTER_DEPTH: usize = 2000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Filter<'a> {


### PR DESCRIPTION
This PR introduces the depth method on the FilterCondition type to be able to react to it. It is meant to be used to reject filters that go too deep and can make the engine stack overflow.