### PR TITLE
Prefer returning `None` instead of using an `FilterCondition::Empty` state

### DIFF
--- a/benchmarks/benches/utils.rs
+++ b/benchmarks/benches/utils.rs
@@ -117,7 +117,7 @@ pub fn run_benches(c: &mut criterion::Criterion, confs: &[Conf]) {
                     let mut search = index.search(&rtxn);
                     search.query(query).optional_words(conf.optional_words);
                     if let Some(filter) = conf.filter {
-                        let filter = Filter::from_str(filter).unwrap();
+                        let filter = Filter::from_str(filter).unwrap().unwrap();
                         search.filter(filter);
                     }
                     if let Some(sort) = &conf.sort {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -250,8 +250,9 @@ impl Search {
         }
 
         if let Some(ref filter) = self.filter {
-            let condition = milli::Filter::from_str(filter)?;
-            search.filter(condition);
+            if let Some(condition) = milli::Filter::from_str(filter)? {
+                search.filter(condition);
+            }
         }
 
         if let Some(offset) = self.offset {

--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -738,7 +738,7 @@ async fn main() -> anyhow::Result<()> {
 
             let filters = match query.filters.as_ref() {
                 Some(condition) if !condition.trim().is_empty() => {
-                    Some(MilliFilter::from_str(condition).unwrap())
+                    MilliFilter::from_str(condition).unwrap()
                 }
                 _otherwise => None,
             };

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -614,19 +614,6 @@ mod tests {
 
     #[test]
     fn filter_depth() {
-        let path = tempfile::tempdir().unwrap();
-        let mut options = EnvOpenOptions::new();
-        options.map_size(10 * 1024 * 1024); // 10 MB
-        let index = Index::new(options, &path).unwrap();
-
-        // Set the filterable fields to be the channel.
-        let mut wtxn = index.write_txn().unwrap();
-        let mut builder = Settings::new(&mut wtxn, &index);
-        builder.set_searchable_fields(vec![S("account_ids")]);
-        builder.set_filterable_fields(hashset! { S("account_ids") });
-        builder.execute(|_| ()).unwrap();
-        wtxn.commit().unwrap();
-
         // generates a big (2 MiB) filter with too much of ORs.
         let tipic_filter = "account_ids=14361 OR ";
         let mut filter_string = String::with_capacity(tipic_filter.len() * 14360);

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -644,4 +644,10 @@ mod tests {
             error.to_string()
         );
     }
+
+    #[test]
+    fn empty_filter() {
+        let option = Filter::from_str("     ").unwrap();
+        assert_eq!(option, None);
+    }
 }

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -681,7 +681,7 @@ mod tests {
         builder.delete_external_id("1_4");
         builder.execute().unwrap();
 
-        let filter = Filter::from_str("label = sign").unwrap();
+        let filter = Filter::from_str("label = sign").unwrap().unwrap();
         let results = index.search(&wtxn).filter(filter).execute().unwrap();
         assert!(results.documents_ids.is_empty());
 

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1060,7 +1060,7 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = index.read_txn().unwrap();
-        let filter = Filter::from_str("toto = 32").unwrap();
+        let filter = Filter::from_str("toto = 32").unwrap().unwrap();
         let _ = filter.evaluate(&rtxn, &index).unwrap_err();
     }
 


### PR DESCRIPTION
This PR is related to the issue comment https://github.com/meilisearch/MeiliSearch/issues/1338#issuecomment-989322889 which exhibits the fact that when a filter is known to be empty no results are returned which is wrong, the filter should not apply as no restriction is done on the documents set.

The filter system on the milli side has introduced an Empty state which was used in this kind of situation but I found out that it is not needed and that when we parse a filter and that it is empty we can simply return `None` as the `Filter::from_array` constructor does. So I removed it and added tests!

On the MeiliSearch side, we just need to match on a `None` and completely ignore the filter in such a case.