### PR TITLE
Store the geopoint in three dimensions

### DIFF
--- a/milli/src/search/criteria/geo.rs
+++ b/milli/src/search/criteria/geo.rs
@@ -5,7 +5,7 @@ use rstar::RTree;
 
 use super::{Criterion, CriterionParameters, CriterionResult};
 use crate::search::criteria::{resolve_query_tree, CriteriaBuilder};
-use crate::{GeoPoint, Index, Result};
+use crate::{lat_lng_to_xyz, GeoPoint, Index, Result};
 
 pub struct Geo<'t> {
     index: &'t Index,
@@ -132,10 +132,12 @@ fn geo_point(
     point: [f64; 2],
     ascending: bool,
 ) -> Box<dyn Iterator<Item = RoaringBitmap>> {
+    let point = lat_lng_to_xyz(&point);
+
     let mut results = Vec::new();
     for point in rtree.nearest_neighbor_iter(&point) {
-        if candidates.remove(point.data) {
-            results.push(std::iter::once(point.data).collect());
+        if candidates.remove(point.data.0) {
+            results.push(std::iter::once(point.data.0).collect());
             if candidates.is_empty() {
                 break;
             }

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -395,9 +395,9 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
 
             let (points_to_remove, docids_to_remove): (Vec<_>, RoaringBitmap) = rtree
                 .iter()
-                .filter(|&point| self.documents_ids.contains(point.data))
+                .filter(|&point| self.documents_ids.contains(point.data.0))
                 .cloned()
-                .map(|point| (point, point.data))
+                .map(|point| (point, point.data.0))
                 .unzip();
             points_to_remove.iter().for_each(|point| {
                 rtree.remove(&point);
@@ -747,7 +747,7 @@ mod tests {
 
         let all_geo_ids = rtree.iter().map(|point| point.data).collect::<Vec<_>>();
         let all_geo_documents = index
-            .documents(&rtxn, all_geo_ids.iter().copied())
+            .documents(&rtxn, all_geo_ids.iter().map(|(id, _)| id).copied())
             .unwrap()
             .iter()
             .map(|(id, _)| *id)


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/MeiliSearch/issues/1872

Fix the whole computation of distance for any “geo” operations (sort or filter). Now when you sort points they are returned to you in the right order.
And when you filter on a specific radius you only get points included in the radius.

This PR changes the way we store the geo points in the RTree.
Instead of considering the latitude and longitude as orthogonal coordinates, we convert them to real orthogonal coordinates projected on a sphere with a radius of 1.
This is the conversion formulae.
![image](https://user-images.githubusercontent.com/7032172/145990456-eefe840a-384f-4486-848b-81d0036814ec.png)
Which, in rust, translate to this function:
```rust
pub fn lat_lng_to_xyz(coord: &[f64; 2]) -> [f64; 3] {
    let [lat, lng] = coord.map(|f| f.to_radians());
    let x = lat.cos() * lng.cos();
    let y = lat.cos() * lng.sin();
    let z = lat.sin();

    [x, y, z]
}
```

Storing the points on a sphere is easier / faster to compute than storing the point on an approximation of the real earth shape.
But when we need to compute the distance between two points we still need to use the haversine distance which works with latitude and longitude.
So, to do the fewest search-time computation possible I'm now associating every point with its `DocId` and its lat/lng.