### PR TITLE
Fix search highlight for non-unicode chars

### DIFF
--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -17,6 +17,7 @@ once_cell = "1.5.2"
 rayon = "1.5.0"
 structopt = { version = "0.3.21", default-features = false, features = ["wrap_help"] }
 tempfile = "3.2.0"
+unicode-segmentation = "1.6.0"
 
 # http server
 askama = "0.10.5"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.38"
 byte-unit = { version = "4.0.9", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.0"
 heed = { git = "https://github.com/Kerollmops/heed", tag = "v0.12.1" }
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.6" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.7" }
 memmap2 = "0.5.0"
 milli = { path = "../milli" }
 once_cell = "1.5.2"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -17,7 +17,6 @@ once_cell = "1.5.2"
 rayon = "1.5.0"
 structopt = { version = "0.3.21", default-features = false, features = ["wrap_help"] }
 tempfile = "3.2.0"
-unicode-segmentation = "1.6.0"
 
 # http server
 askama = "0.10.5"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -22,7 +22,7 @@ heed = { git = "https://github.com/Kerollmops/heed", tag = "v0.12.1", default-fe
 human_format = "1.0.3"
 levenshtein_automata = { version = "0.2.0", features = ["fst_automaton"] }
 linked-hash-map = "0.5.4"
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.6" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.7" }
 memmap2 = "0.5.0"
 obkv = "0.2.0"
 once_cell = "1.5.2"

--- a/milli/src/search/matching_words.rs
+++ b/milli/src/search/matching_words.rs
@@ -42,10 +42,7 @@ impl MatchingWords {
                         let len = bytes_to_highlight(word_to_highlight.text(), query_word);
                         Some(word_to_highlight.num_chars_from_bytes(len))
                     } else {
-                        Some(
-                            word_to_highlight
-                                .num_chars_from_bytes(word_to_highlight.text().len()),
-                        )
+                        Some(word_to_highlight.num_chars_from_bytes(word_to_highlight.text().len()))
                     }
                 }
                 _otherwise => None,
@@ -276,61 +273,82 @@ mod tests {
 
         let matching_words = MatchingWords::from_query_tree(&query_tree);
 
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("word"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "word".len(),
-            char_map: None,
-        }), Some(3));
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("nyc"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "nyc".len(),
-            char_map: None,
-        }), None);
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("world"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "world".len(),
-            char_map: None,
-        }), Some(5));
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("splitted"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "splitted".len(),
-            char_map: None,
-        }), Some(5));
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("thisnew"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "thisnew".len(),
-            char_map: None,
-        }), None);
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("borld"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "borld".len(),
-            char_map: None,
-        }), Some(5));
-        assert_eq!(matching_words.matching_bytes(&Token{
-            kind: TokenKind::Word,
-            word: Cow::Borrowed("wordsplit"),
-            byte_start: 0,
-            char_index: 0,
-            byte_end: "wordsplit".len(),
-            char_map: None,
-        }), Some(4));
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("word"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "word".len(),
+                char_map: None,
+            }),
+            Some(3)
+        );
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("nyc"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "nyc".len(),
+                char_map: None,
+            }),
+            None
+        );
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("world"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "world".len(),
+                char_map: None,
+            }),
+            Some(5)
+        );
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("splitted"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "splitted".len(),
+                char_map: None,
+            }),
+            Some(5)
+        );
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("thisnew"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "thisnew".len(),
+                char_map: None,
+            }),
+            None
+        );
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("borld"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "borld".len(),
+                char_map: None,
+            }),
+            Some(5)
+        );
+        assert_eq!(
+            matching_words.matching_bytes(&Token {
+                kind: TokenKind::Word,
+                word: Cow::Borrowed("wordsplit"),
+                byte_start: 0,
+                char_index: 0,
+                byte_end: "wordsplit".len(),
+                char_map: None,
+            }),
+            Some(4)
+        );
     }
 }

--- a/milli/src/search/matching_words.rs
+++ b/milli/src/search/matching_words.rs
@@ -40,11 +40,11 @@ impl MatchingWords {
                 Distance::Exact(t) if t <= *typo => {
                     if *is_prefix {
                         let len = bytes_to_highlight(word_to_highlight.text(), query_word);
-                        Some(word_to_highlight.num_graphemes_from_bytes(len))
+                        Some(word_to_highlight.num_chars_from_bytes(len))
                     } else {
                         Some(
                             word_to_highlight
-                                .num_graphemes_from_bytes(word_to_highlight.text().len()),
+                                .num_chars_from_bytes(word_to_highlight.text().len()),
                         )
                     }
                 }

--- a/milli/src/search/matching_words.rs
+++ b/milli/src/search/matching_words.rs
@@ -182,7 +182,10 @@ fn bytes_to_highlight(source: &str, target: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::str::from_utf8;
+
+    use meilisearch_tokenizer::TokenKind;
 
     use super::*;
     use crate::search::query_tree::{Operation, Query, QueryKind};
@@ -273,12 +276,61 @@ mod tests {
 
         let matching_words = MatchingWords::from_query_tree(&query_tree);
 
-        assert_eq!(matching_words.matching_bytes("word"), Some(3));
-        assert_eq!(matching_words.matching_bytes("nyc"), None);
-        assert_eq!(matching_words.matching_bytes("world"), Some(5));
-        assert_eq!(matching_words.matching_bytes("splitted"), Some(5));
-        assert_eq!(matching_words.matching_bytes("thisnew"), None);
-        assert_eq!(matching_words.matching_bytes("borld"), Some(5));
-        assert_eq!(matching_words.matching_bytes("wordsplit"), Some(4));
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("word"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "word".len(),
+            char_map: None,
+        }), Some(3));
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("nyc"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "nyc".len(),
+            char_map: None,
+        }), None);
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("world"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "world".len(),
+            char_map: None,
+        }), Some(5));
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("splitted"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "splitted".len(),
+            char_map: None,
+        }), Some(5));
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("thisnew"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "thisnew".len(),
+            char_map: None,
+        }), None);
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("borld"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "borld".len(),
+            char_map: None,
+        }), Some(5));
+        assert_eq!(matching_words.matching_bytes(&Token{
+            kind: TokenKind::Word,
+            word: Cow::Borrowed("wordsplit"),
+            byte_start: 0,
+            char_index: 0,
+            byte_end: "wordsplit".len(),
+            char_map: None,
+        }), Some(4));
     }
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes https://github.com/meilisearch/MeiliSearch/issues/1480
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## Changes

The `matching_bytes` function takes a `&Token` now and:
- gets the number of bytes to highlight (unchanged).
- uses `Token.num_graphemes_from_bytes` to get the number of grapheme clusters to highlight.

In essence, the `matching_bytes` function now returns the number of matching grapheme clusters instead of bytes.

Added proper highlighting in the HTTP UI:
- requires dependency on `unicode-segmentation` to extract grapheme clusters from tokens
- `<mark>` tag is put around only the matched part
    - before this change, the entire word was highlighted even if only a part of it matched

## Questions

Since `matching_bytes` does not return number of bytes but grapheme clusters, should it be renamed to something like `matching_chars` or `matching_graphemes`? Will this break the API?

Thank you very much @ManyTheFish for helping :smile: 