### PR TITLE
Benchmark CIs: not use a default label to call the GH runner

### DIFF
--- a/.github/workflows/manual_benchmarks.yml
+++ b/.github/workflows/manual_benchmarks.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   benchmarks:
     name: Run and upload benchmarks
-    runs-on: self-hosted
+    runs-on: benchmarks
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/push_benchmarks_indexing.yml
+++ b/.github/workflows/push_benchmarks_indexing.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   benchmarks:
     name: Run and upload benchmarks
-    runs-on: self-hosted
+    runs-on: benchmarks
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/push_benchmarks_search_geo.yml
+++ b/.github/workflows/push_benchmarks_search_geo.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   benchmarks:
     name: Run and upload benchmarks
-    runs-on: self-hosted
+    runs-on: benchmarks
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/push_benchmarks_search_songs.yml
+++ b/.github/workflows/push_benchmarks_search_songs.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   benchmarks:
     name: Run and upload benchmarks
-    runs-on: self-hosted
+    runs-on: benchmarks
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/push_benchmarks_search_wiki.yml
+++ b/.github/workflows/push_benchmarks_search_wiki.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   benchmarks:
     name: Run and upload benchmarks
-    runs-on: self-hosted
+    runs-on: benchmarks
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Since we now have multiple self-hosted github runners, we need to differentiate them calling them in the CI. The `self-hosted` label is the default one, so we need to use the unique and appropriate one for the benchmark machine

<img width="925" alt="Capture d’écran 2022-01-04 à 15 42 18" src="https://user-images.githubusercontent.com/20380692/148079840-49cd7878-5912-46ff-8ab8-bf646777f782.png">
