### PR TITLE
Fix and improve word prefix pair proximity

### DIFF
--- a/milli/src/update/word_prefix_pair_proximity_docids.rs
+++ b/milli/src/update/word_prefix_pair_proximity_docids.rs
@@ -40,22 +40,21 @@ impl<'t, 'u, 'i> WordPrefixPairProximityDocids<'t, 'u, 'i> {
     }
 
     /// Set the maximum proximity required to make a prefix be part of the words prefixes
-    /// database. If two words are two far from the threshold the associated documents will
+    /// database. If two words are too far from the threshold the associated documents will
     /// not be part of the prefix database.
     ///
-    /// Default value is 4. This value must be lower or equal than 4 and will be clamped
+    /// Default value is 4. This value must be lower or equal than 7 and will be clamped
     /// to this bound otherwise.
     pub fn max_proximity(&mut self, value: u8) -> &mut Self {
         self.max_proximity = value.max(7);
         self
     }
 
-    /// Set the maximum length the prefix of a word pair is allowed to have be part of the words
-    /// prefixes database. If two words are two far from the threshold the associated documents
+    /// Set the maximum length the prefix of a word pair is allowed to have to be part of the words
+    /// prefixes database. If the prefix length is higher than the threshold, the associated documents
     /// will not be part of the prefix database.
     ///
-    /// Default value is 4. This value must be lower or equal than 4 and will be clamped
-    /// to this bound otherwise.
+    /// Default value is 2.
     pub fn max_prefix_length(&mut self, value: usize) -> &mut Self {
         self.max_prefix_length = value;
         self


### PR DESCRIPTION
This PR first fixes the algorithm we used to select and compute the word prefix pair proximity database. The previous version was skipping nearly all of the prefixes. The issue is that this fix made this method to take more time and we were trying to reduce the time spent in it.

With @ManyTheFish we found out that we could skip some of the work we were doing by:
 - discarding the prefixes that were shorter than a specific threshold (default: 2).
 - discarding the word prefix pairs with proximity bigger than a specific threshold (default: 4).
 - remove the unused threshold that was specifying a minimum amount of word docids to merge.

We will take more time to do some more optimization, like stop clearing and recomputing from scratch the database, we will compute the subsets of keys to create, keep and merge. This change is a little bit more complex than what this PR does.

I keep this PR as a draft as I want to further test the real gain if it is enough or not if it is valid or not. I advise reviewers to review commit by commit to see the changes bit by bit, reviewing the whole PR can be hard.