### PR TITLE
bump milli to v0.22.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
This is breaking because of this PR:
https://github.com/meilisearch/milli/commit/98a365aaae53e2d543f65f5261811a23dad65660

Should we do a special branch to only release the [patch](https://github.com/meilisearch/milli/pull/433) for https://github.com/meilisearch/MeiliSearch/issues/2082 (which is non-breaking)?