### PR TITLE
POC scopes

### DIFF
--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -31,6 +31,7 @@ impl<'t, 'u, 'i> ClearDocuments<'t, 'u, 'i> {
             field_id_docid_facet_f64s,
             field_id_docid_facet_strings,
             documents,
+            users: _,
         } = self.index;
 
         // We retrieve the number of documents ids that we are deleting.

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -120,6 +120,7 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
             field_id_docid_facet_f64s,
             field_id_docid_facet_strings,
             documents,
+            users: _,
         } = self.index;
 
         // Number of fields for each document that has been deleted.


### PR DESCRIPTION
# POC Scopes

## DISCLAIMER: this description is still pretty WIP

Issues like https://github.com/meilisearch/meilisearch/issues/2163 show us that there is a use case gap that is not filled by either tenant token or filters. I see it as a typical pattern that you would want to allow certain users to see certain documents, while the nature of the relation is not necessarily structured (there may not be propers categories to encode that). Currently, there are two ways one can do that in meilisearch:

- Created huge filter expressions that filter documents 1 by 1 (or small category by small category). We can see that this method does not scale: the query size quickly becomes huge, on building such a filter quickly becomes expensive, both on the client-side and on meilisearch side.
- Associate each document with a set of users that can access them. This field can be set as nonsearchable and nondisplayed, but filterable. This method comes with a bunch of issues in itself: first, updating users requires reindexing documents, which is not desirable, second the size of the documents grows with the number of users that are allowed to see it. This is better than the first method, but still far from desirable.

Another use case that was brought by a user, was to have dynamic lists of documents, where documents can belong to multiple lists, and change dynamically. Right now, the only way to do this is through re-indexing.

To address the status quo, it seems that we need to introduce a new mechanism to handle such cases. In this pr, I implement a POC of such a system that I call `scope`.

A scope is a list of documents that can be used as a filter. A user can define scopes by naming them and providing a list of document ids belonging to them. In a query, or in a tenant token, the scope can be passed to restrict the document to the one in the provided scoped.

The advantages of this method are obvious:
- Managing what document a user is allowed to see is independent of indexing.
- Storing what document a user is allowed to see is rather cheap since they are compressed into `RoaringBitmap`s
- Almost no search time overhead, ultimately this is treated as a mere filter.

There are still multiple things that need to be addressed:
- Dealing with document deletions: We need to go through all users and delete the documents from their allowed documents. There may be easy optimization for that, such as only redeeming document ids when there aren't enough that can be created by incrementing the id.
- building a user-facing API, for now, this is only testable through the client
- How should those updates be handled? How should they be scheduled?
- How do we design an API to manage many users conveniently?
- Do we want dynamic rules for what a user is allowed to see (i.e a user can see anything with the tag `red`...), more complex too, and maybe already handled with tenant token


We may want to make that an experimental feature to figure it out.

### example usage:

```
~/Documents/code/rust/milli/cli user-management *1 ?4 ······················································································· 15:27:35
❯ cargo r -- settings user --name marin --ids 1 2 3
    Finished dev [optimized + debuginfo] target(s) in 0.11s
     Running `/Users/mpostma/Documents/code/rust/milli/target/debug/cli settings user --name marin --ids 1 2 3`

~/Documents/code/rust/milli/cli user-management *1 ?4 ······················································································· 15:27:37
❯ cargo r -- search hello
    Finished dev [optimized + debuginfo] target(s) in 0.06s
     Running `/Users/mpostma/Documents/code/rust/milli/target/debug/cli search hello`
[
  {
    "id": 1,
    "text": "hello"
  },
  {
    "id": 2,
    "text": "hello"
  },
  {
    "id": 3,
    "text": "hello"
  },
  {
    "id": 4,
    "text": "hello"
  }
]
found 4 results in 164.58µs

~/Documents/code/rust/milli/cli user-management *1 ?4 ······················································································· 15:27:50
❯ cargo r -- search -u marin hello
    Finished dev [optimized + debuginfo] target(s) in 0.06s
     Running `/Users/mpostma/Documents/code/rust/milli/target/debug/cli search -u marin hello`
[
  {
    "id": 1,
    "text": "hello"
  },
  {
    "id": 2,
    "text": "hello"
  },
  {
    "id": 3,
    "text": "hello"
  }
]
found 3 results in 128.71µs
```