### PR TITLE
Get rid of chrono in favor of time

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -9,7 +9,6 @@ bimap = { version = "0.6.1", features = ["serde"] }
 bincode = "1.3.3"
 bstr = "0.2.15"
 byteorder = "1.4.2"
-chrono = { version = "0.4.19", features = ["serde"] }
 concat-arrays = "0.1.2"
 crossbeam-channel = "0.5.1"
 either = "1.6.1"
@@ -36,6 +35,7 @@ slice-group-by = "0.2.6"
 smallstr =  { version = "0.2.0", features = ["serde"] }
 smallvec = "1.6.1"
 tempfile = "3.2.0"
+time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 
 filter-parser = { path = "../filter-parser" }

--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -1,5 +1,5 @@
-use chrono::Utc;
 use roaring::RoaringBitmap;
+use time::OffsetDateTime;
 
 use crate::{ExternalDocumentsIds, FieldDistribution, Index, Result};
 
@@ -14,7 +14,7 @@ impl<'t, 'u, 'i> ClearDocuments<'t, 'u, 'i> {
     }
 
     pub fn execute(self) -> Result<u64> {
-        self.index.set_updated_at(self.wtxn, &Utc::now())?;
+        self.index.set_updated_at(self.wtxn, &OffsetDateTime::now_utc())?;
         let Index {
             env: _env,
             main: _main,

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -1,13 +1,13 @@
 use std::collections::btree_map::Entry;
 use std::collections::HashMap;
 
-use chrono::Utc;
 use fst::IntoStreamer;
 use heed::types::ByteSlice;
 use heed::{BytesDecode, BytesEncode};
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use time::OffsetDateTime;
 
 use super::ClearDocuments;
 use crate::error::{InternalError, SerializationError, UserError};
@@ -61,7 +61,7 @@ impl<'t, 'u, 'i> DeleteDocuments<'t, 'u, 'i> {
     }
 
     pub fn execute(self) -> Result<DocumentDeletionResult> {
-        self.index.set_updated_at(self.wtxn, &Utc::now())?;
+        self.index.set_updated_at(self.wtxn, &OffsetDateTime::now_utc())?;
         // We retrieve the current documents ids that are in the database.
         let mut documents_ids = self.index.documents_ids(self.wtxn)?;
         let current_documents_ids_len = documents_ids.len();

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -2,12 +2,12 @@ use std::fs::File;
 use std::num::{NonZeroU8, NonZeroUsize};
 use std::{cmp, mem};
 
-use chrono::Utc;
 use grenad::{CompressionType, Reader, Writer};
 use heed::types::{ByteSlice, DecodeIgnore};
 use heed::{BytesEncode, Error};
 use log::debug;
 use roaring::RoaringBitmap;
+use time::OffsetDateTime;
 
 use crate::error::InternalError;
 use crate::heed_codec::facet::{
@@ -53,7 +53,7 @@ impl<'t, 'u, 'i> Facets<'t, 'u, 'i> {
 
     #[logging_timer::time("Facets::{}")]
     pub fn execute(self) -> Result<()> {
-        self.index.set_updated_at(self.wtxn, &Utc::now())?;
+        self.index.set_updated_at(self.wtxn, &OffsetDateTime::now_utc())?;
         // We get the faceted fields to be able to create the facet levels.
         let faceted_fields = self.index.faceted_fields_ids(self.wtxn)?;
 

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1,10 +1,10 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::result::Result as StdResult;
 
-use chrono::Utc;
 use itertools::Itertools;
 use meilisearch_tokenizer::{Analyzer, AnalyzerConfig};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use time::OffsetDateTime;
 
 use super::index_documents::{IndexDocumentsConfig, Transform};
 use super::IndexerConfig;
@@ -454,7 +454,7 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
     where
         F: Fn(UpdateIndexingStep) + Sync,
     {
-        self.index.set_updated_at(self.wtxn, &Utc::now())?;
+        self.index.set_updated_at(self.wtxn, &OffsetDateTime::now_utc())?;
 
         let old_faceted_fields = self.index.faceted_fields(&self.wtxn)?;
         let old_fields_ids_map = self.index.fields_ids_map(&self.wtxn)?;


### PR DESCRIPTION
We only use `chrono` as a wrapper around `time`, and since there has been an [open CVE on `chrono` for at least 3 months now](https://github.com/chronotope/chrono/pull/632) and the repo seems to be [struggling with maintenance](https://github.com/chronotope/chrono/pull/639), I think we should use `time` directly which is way more active and sufficient for our use case.

EDIT: Actually the CVE status has been known for more than 6 months: https://github.com/chronotope/chrono/issues/602