### PR TITLE
Nested fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["milli", "filter-parser", "http-ui", "benchmarks", "infos", "helpers", "cli"]
+members = ["milli", "filter-parser", "flatten-serde-json", "http-ui", "benchmarks", "infos", "helpers", "cli"]
 default-members = ["milli"]
 
 [profile.dev]

--- a/benchmarks/benches/indexing.rs
+++ b/benchmarks/benches/indexing.rs
@@ -70,7 +70,8 @@ fn indexing_songs_default(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS, "csv");
                 builder.add_documents(documents).unwrap();
@@ -120,7 +121,8 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                 let config = IndexerConfig::default();
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS_1_2, "csv");
                 builder.add_documents(documents).unwrap();
                 builder.execute().unwrap();
@@ -134,14 +136,16 @@ fn indexing_songs_in_three_batches_default(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS_3_4, "csv");
                 builder.add_documents(documents).unwrap();
                 builder.execute().unwrap();
 
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS_4_4, "csv");
                 builder.add_documents(documents).unwrap();
                 builder.execute().unwrap();
@@ -190,7 +194,8 @@ fn indexing_songs_without_faceted_numbers(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS, "csv");
 
@@ -236,7 +241,8 @@ fn indexing_songs_without_faceted_fields(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::SMOL_SONGS, "csv");
                 builder.add_documents(documents).unwrap();
@@ -281,7 +287,8 @@ fn indexing_wiki(c: &mut Criterion) {
                     IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::SMOL_WIKI_ARTICLES, "csv");
                 builder.add_documents(documents).unwrap();
@@ -323,7 +330,8 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                 let indexing_config =
                     IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
                 let documents =
                     utils::documents_from(datasets_paths::SMOL_WIKI_ARTICLES_1_2, "csv");
                 builder.add_documents(documents).unwrap();
@@ -339,7 +347,8 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                     IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents =
                     utils::documents_from(datasets_paths::SMOL_WIKI_ARTICLES_3_4, "csv");
@@ -349,7 +358,8 @@ fn indexing_wiki_in_three_batches(c: &mut Criterion) {
                 let indexing_config =
                     IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents =
                     utils::documents_from(datasets_paths::SMOL_WIKI_ARTICLES_4_4, "csv");
@@ -400,7 +410,8 @@ fn indexing_movies_default(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::MOVIES, "json");
                 builder.add_documents(documents).unwrap();
@@ -447,7 +458,8 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                 let config = IndexerConfig::default();
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::MOVIES_1_2, "json");
                 builder.add_documents(documents).unwrap();
@@ -462,7 +474,8 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::MOVIES_3_4, "json");
                 builder.add_documents(documents).unwrap();
@@ -470,7 +483,8 @@ fn indexing_movies_in_three_batches(c: &mut Criterion) {
 
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::MOVIES_4_4, "json");
                 builder.add_documents(documents).unwrap();
@@ -525,7 +539,8 @@ fn indexing_geo(c: &mut Criterion) {
                 let indexing_config = IndexDocumentsConfig::default();
                 let mut wtxn = index.write_txn().unwrap();
                 let mut builder =
-                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+                    IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ())
+                        .unwrap();
 
                 let documents = utils::documents_from(datasets_paths::SMOL_ALL_COUNTRIES, "jsonl");
                 builder.add_documents(documents).unwrap();

--- a/benchmarks/benches/utils.rs
+++ b/benchmarks/benches/utils.rs
@@ -96,7 +96,8 @@ pub fn base_setup(conf: &Conf) -> Index {
         update_method: IndexDocumentsMethod::ReplaceDocuments,
         ..Default::default()
     };
-    let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+    let mut builder =
+        IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
     let documents = documents_from(conf.dataset, conf.dataset_format);
 
     builder.add_documents(documents).unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,7 +261,8 @@ impl Performer for DocumentAddition {
             &config,
             indexing_config,
             |step| indexing_callback(step, &bars),
-        );
+        )
+        .unwrap();
         addition.add_documents(reader)?;
 
         std::thread::spawn(move || {

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "flatten-serde-json"
+version = "0.1.0"
+edition = "2021"
+description = "Flatten serde-json objects like elastic search"
+readme = "README.md"
+author = ["Tamo tamo@meilisearch.com"]
+repository = "https://github.com/irevoire/flatten-serde-json"
+keywords = ["json", "flatten"]
+categories = ["command-line-utilities"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde_json = "1.0"

--- a/flatten-serde-json/README.md
+++ b/flatten-serde-json/README.md
@@ -1,0 +1,153 @@
+# Flatten serde Json
+
+This crate flatten [`serde_json`](https://docs.rs/serde_json/latest/serde_json/) `Object` in a format
+similar to [elastic search](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html).
+
+## Examples
+
+### There is nothing to do
+
+```json
+{
+  "id": "287947",
+  "title": "Shazam!",
+  "release_date": 1553299200,
+  "genres": [
+    "Action",
+    "Comedy",
+    "Fantasy"
+  ]
+}
+```
+
+Flattens to:
+```json
+{
+  "id": "287947",
+  "title": "Shazam!",
+  "release_date": 1553299200,
+  "genres": [
+    "Action",
+    "Comedy",
+    "Fantasy"
+  ]
+}
+```
+
+------------
+
+### Objects
+
+```json
+{
+  "a": {
+    "b": "c",
+    "d": "e",
+    "f": "g"
+  }
+}
+```
+
+Flattens to:
+```json
+{
+  "a.b": "c",
+  "a.d": "e",
+  "a.f": "g"
+}
+```
+
+------------
+
+### Array of objects
+
+```json
+{
+  "a": [
+    { "b": "c" },
+    { "b": "d" },
+    { "b": "e" },
+  ]
+}
+```
+
+Flattens to:
+```json
+{
+  "a.b": ["c", "d", "e"],
+}
+```
+
+------------
+
+### Array of objects with normal value in the array
+
+```json
+{
+  "a": [
+    42,
+    { "b": "c" },
+    { "b": "d" },
+    { "b": "e" },
+  ]
+}
+```
+
+Flattens to:
+```json
+{
+  "a": 42,
+  "a.b": ["c", "d", "e"],
+}
+```
+
+------------
+
+### Array of objects of array of objects of ...
+
+```json
+{
+  "a": [
+    "b",
+    ["c", "d"],
+    { "e": ["f", "g"] },
+    [
+        { "h": "i" },
+        { "e": ["j", { "z": "y" }] },
+    ],
+    ["l"],
+    "m",
+  ]
+}
+```
+
+Flattens to:
+```json
+{
+  "a": ["b", "c", "d", "l", "m"],
+  "a.e": ["f", "g", "j"],
+  "a.h": "i",
+  "a.e.z": "y",
+}
+```
+
+------------
+
+### Collision between a generated field name and an already existing field
+
+```json
+{
+  "a": {
+    "b": "c",
+  },
+  "a.b": "d",
+}
+```
+
+Flattens to:
+```json
+{
+  "a.b": ["c", "d"],
+}
+```
+

--- a/flatten-serde-json/fuzz/Cargo.toml
+++ b/flatten-serde-json/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "flatten_serde_json-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary-json = "0.1.1"
+
+[dependencies.flatten_serde_json]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "flatten"
+path = "fuzz_targets/flatten.rs"
+test = false
+doc = false

--- a/flatten-serde-json/fuzz/fuzz_targets/flatten.rs
+++ b/flatten-serde-json/fuzz/fuzz_targets/flatten.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use arbitrary_json::ArbitraryObject;
+use flatten_serde_json::flatten;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|object: ArbitraryObject| {
+    let _ = flatten(&object);
+});

--- a/flatten-serde-json/src/lib.rs
+++ b/flatten-serde-json/src/lib.rs
@@ -1,0 +1,264 @@
+#![doc = include_str!("../README.md")]
+
+use serde_json::{json, Map, Value};
+
+pub fn flatten(json: &Map<String, Value>) -> Map<String, Value> {
+    let mut obj = Map::new();
+    insert_object(&mut obj, None, json);
+    obj
+}
+
+fn insert_object(
+    base_json: &mut Map<String, Value>,
+    base_key: Option<&str>,
+    object: &Map<String, Value>,
+) {
+    for (key, value) in object {
+        let new_key = base_key.map_or_else(|| key.clone(), |base_key| format!("{base_key}.{key}"));
+
+        if let Some(array) = value.as_array() {
+            insert_array(base_json, &new_key, array);
+        } else if let Some(object) = value.as_object() {
+            insert_object(base_json, Some(&new_key), object);
+        } else {
+            insert_value(base_json, &new_key, value.clone());
+        }
+    }
+}
+
+fn insert_array(base_json: &mut Map<String, Value>, base_key: &str, array: &Vec<Value>) {
+    for value in array {
+        if let Some(object) = value.as_object() {
+            insert_object(base_json, Some(base_key), object);
+        } else if let Some(sub_array) = value.as_array() {
+            insert_array(base_json, base_key, sub_array);
+        } else {
+            insert_value(base_json, base_key, value.clone());
+        }
+    }
+}
+
+fn insert_value(base_json: &mut Map<String, Value>, key: &str, to_insert: Value) {
+    debug_assert!(!to_insert.is_object());
+    debug_assert!(!to_insert.is_array());
+
+    // does the field aleardy exists?
+    if let Some(value) = base_json.get_mut(key) {
+        // is it already an array
+        if let Some(array) = value.as_array_mut() {
+            array.push(to_insert);
+        // or is there a collision
+        } else {
+            let value = std::mem::take(value);
+            base_json[key] = json!([value, to_insert]);
+        }
+        // if it does not exist we can push the value untouched
+    } else {
+        base_json.insert(key.to_string(), json!(to_insert));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_flattening() {
+        let mut base: Value = json!({
+          "id": "287947",
+          "title": "Shazam!",
+          "release_date": 1553299200,
+          "genres": [
+            "Action",
+            "Comedy",
+            "Fantasy"
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        println!(
+            "got:\n{}\nexpected:\n{}\n",
+            serde_json::to_string_pretty(&flat).unwrap(),
+            serde_json::to_string_pretty(&json).unwrap()
+        );
+
+        assert_eq!(flat, json);
+    }
+
+    #[test]
+    fn flatten_object() {
+        let mut base: Value = json!({
+          "a": {
+            "b": "c",
+            "d": "e",
+            "f": "g"
+          }
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": "c",
+                "a.d": "e",
+                "a.f": "g"
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn flatten_array() {
+        let mut base: Value = json!({
+          "a": [
+            { "b": "c" },
+            { "b": "d" },
+            { "b": "e" },
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": ["c", "d", "e"],
+            })
+            .as_object()
+            .unwrap()
+        );
+
+        // here we must keep 42 in "a"
+        let mut base: Value = json!({
+          "a": [
+            42,
+            { "b": "c" },
+            { "b": "d" },
+            { "b": "e" },
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a": 42,
+                "a.b": ["c", "d", "e"],
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn collision_with_object() {
+        let mut base: Value = json!({
+          "a": {
+            "b": "c",
+          },
+          "a.b": "d",
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": ["c", "d"],
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn collision_with_array() {
+        let mut base: Value = json!({
+          "a": [
+            { "b": "c" },
+            { "b": "d", "c": "e" },
+            [35],
+          ],
+          "a.b": "f",
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": ["c", "d", "f"],
+                "a.c": "e",
+                "a": 35,
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn flatten_nested_arrays() {
+        let mut base: Value = json!({
+          "a": [
+            ["b", "c"],
+            { "d": "e" },
+            ["f", "g"],
+            [
+                { "h": "i" },
+                { "d": "j" },
+            ],
+            ["k", "l"],
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a": ["b", "c", "f", "g", "k", "l"],
+                "a.d": ["e", "j"],
+                "a.h": "i",
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn flatten_nested_arrays_and_objects() {
+        let mut base: Value = json!({
+          "a": [
+            "b",
+            ["c", "d"],
+            { "e": ["f", "g"] },
+            [
+                { "h": "i" },
+                { "e": ["j", { "z": "y" }] },
+            ],
+            ["l"],
+            "m",
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten(&json);
+
+        println!("{}", serde_json::to_string_pretty(&flat).unwrap());
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a": ["b", "c", "d", "l", "m"],
+                "a.e": ["f", "g", "j"],
+                "a.h": "i",
+                "a.e.z": "y",
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+}

--- a/flatten-serde-json/src/main.rs
+++ b/flatten-serde-json/src/main.rs
@@ -1,0 +1,11 @@
+use std::io::stdin;
+
+use flatten_serde_json::flatten;
+use serde_json::{Map, Value};
+
+fn main() {
+    let json: Map<String, Value> = serde_json::from_reader(stdin()).unwrap();
+
+    let result = flatten(&json);
+    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+}

--- a/http-ui/src/main.rs
+++ b/http-ui/src/main.rs
@@ -410,7 +410,7 @@ async fn main() -> anyhow::Result<()> {
                         GLOBAL_CONFIG.get().unwrap(),
                         indexing_config,
                         indexing_callback,
-                    );
+                    )?;
 
                     let reader = match encoding.as_deref() {
                         Some("gzip") => Box::new(GzDecoder::new(content)),

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -14,7 +14,7 @@ crossbeam-channel = "0.5.2"
 either = "1.6.1"
 fst = "0.4.7"
 fxhash = "0.2.1"
-flatten-serde-json = "0.1.0"
+flatten-serde-json = { path = "../flatten-serde-json" }
 grenad = { version = "0.4.1", default-features = false, features = ["tempfile"] }
 geoutils = "0.4.1"
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.1", default-features = false, features = ["lmdb", "sync-read-txn"] }

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -14,6 +14,7 @@ crossbeam-channel = "0.5.2"
 either = "1.6.1"
 fst = "0.4.7"
 fxhash = "0.2.1"
+flatten-serde-json = "0.1.0"
 grenad = { version = "0.4.1", default-features = false, features = ["tempfile"] }
 geoutils = "0.4.1"
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.1", default-features = false, features = ["lmdb", "sync-read-txn"] }

--- a/milli/src/documents/mod.rs
+++ b/milli/src/documents/mod.rs
@@ -49,6 +49,24 @@ impl DocumentsBatchIndex {
     pub fn name(&self, id: FieldId) -> Option<&String> {
         self.0.get_by_left(&id)
     }
+
+    pub fn recreate_json(
+        &self,
+        document: &obkv::KvReaderU16,
+    ) -> Result<serde_json::Map<String, serde_json::Value>, crate::Error> {
+        let mut map = serde_json::Map::new();
+
+        for (k, v) in document.iter() {
+            // TODO: TAMO: update the error type
+            let key =
+                self.0.get_by_left(&k).ok_or(crate::error::InternalError::DatabaseClosing)?.clone();
+            let value = serde_json::from_slice::<serde_json::Value>(v)
+                .map_err(crate::error::InternalError::SerdeJson)?;
+            map.insert(key, value);
+        }
+
+        Ok(map)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -27,6 +27,7 @@ pub enum InternalError {
     DatabaseClosing,
     DatabaseMissingEntry { db_name: &'static str, key: Option<&'static str> },
     FieldIdMapMissingEntry(FieldIdMapMissingEntry),
+    FieldIdMappingMissingEntry { key: FieldId },
     Fst(fst::Error),
     GrenadInvalidCompressionType,
     GrenadInvalidFormatVersion,
@@ -59,7 +60,7 @@ pub enum UserError {
     DocumentLimitReached,
     InvalidDocumentId { document_id: Value },
     InvalidFacetsDistribution { invalid_facets_name: BTreeSet<String> },
-    InvalidGeoField { document_id: Value, object: Value },
+    InvalidGeoField { document_id: Value },
     InvalidFilter(String),
     InvalidSortableAttribute { field: String, valid_fields: BTreeSet<String> },
     SortRankingRuleMissing,
@@ -187,6 +188,9 @@ impl fmt::Display for InternalError {
                 write!(f, "Missing {} in the {} database.", key.unwrap_or("key"), db_name)
             }
             Self::FieldIdMapMissingEntry(error) => error.fmt(f),
+            Self::FieldIdMappingMissingEntry { key } => {
+                write!(f, "Missing {} in the field id mapping.", key)
+            }
             Self::Fst(error) => error.fmt(f),
             Self::GrenadInvalidCompressionType => {
                 f.write_str("Invalid compression type have been specified to grenad.")
@@ -226,19 +230,15 @@ impl fmt::Display for UserError {
                     name_list
                 )
             }
-            Self::InvalidGeoField { document_id, object } => {
+            Self::InvalidGeoField { document_id } => {
                 let document_id = match document_id {
                     Value::String(id) => id.clone(),
                     _ => document_id.to_string(),
                 };
-                let object = match object {
-                    Value::String(id) => id.clone(),
-                    _ => object.to_string(),
-                };
                 write!(
                     f,
-                    "The document with the id: `{}` contains an invalid _geo field: `{}`.",
-                    document_id, object
+                    "The document with the id: `{}` contains an invalid `_geo` field.",
+                    document_id
                 )
             },
             Self::InvalidDocumentId { document_id } => {

--- a/milli/src/search/distinct/mod.rs
+++ b/milli/src/search/distinct/mod.rs
@@ -97,7 +97,8 @@ mod test {
             update_method: IndexDocumentsMethod::ReplaceDocuments,
             ..Default::default()
         };
-        let mut addition = IndexDocuments::new(&mut txn, &index, &config, indexing_config, |_| ());
+        let mut addition =
+            IndexDocuments::new(&mut txn, &index, &config, indexing_config, |_| ()).unwrap();
 
         let reader =
             crate::documents::DocumentBatchReader::from_reader(Cursor::new(&*JSON)).unwrap();

--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -353,7 +353,8 @@ impl<'a> Filter<'a> {
         match &self.condition {
             FilterCondition::Condition { fid, op } => {
                 let filterable_fields = index.filterable_fields(rtxn)?;
-                if filterable_fields.contains(fid.value()) {
+
+                if crate::is_faceted(fid.value(), &filterable_fields) {
                     let field_ids_map = index.fields_ids_map(rtxn)?;
                     if let Some(fid) = field_ids_map.id(fid.value()) {
                         Self::evaluate_operator(rtxn, index, numbers_db, strings_db, fid, &op)
@@ -549,7 +550,6 @@ mod tests {
             Filter::from_str("channel = gotaga AND (timestamp = 44 OR channel != ponce)")
                 .unwrap()
                 .unwrap();
-        println!("\nExpecting: {:#?}\nGot: {:#?}\n", expected, condition);
         assert_eq!(condition, expected);
     }
 

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -159,7 +159,7 @@ impl<'a> Search<'a> {
             let sortable_fields = self.index.sortable_fields(self.rtxn)?;
             for asc_desc in sort_criteria {
                 match asc_desc.member() {
-                    Member::Field(ref field) if !sortable_fields.contains(field) => {
+                    Member::Field(ref field) if !crate::is_faceted(field, &sortable_fields) => {
                         return Err(UserError::InvalidSortableAttribute {
                             field: field.to_string(),
                             valid_fields: sortable_fields.into_iter().collect(),

--- a/milli/src/update/clear_documents.rs
+++ b/milli/src/update/clear_documents.rs
@@ -98,7 +98,8 @@ mod tests {
         ]);
         let indexing_config = IndexDocumentsConfig::default();
         let config = IndexerConfig::default();
-        let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
         builder.add_documents(content).unwrap();
         builder.execute().unwrap();
 
@@ -110,7 +111,8 @@ mod tests {
 
         let rtxn = index.read_txn().unwrap();
 
-        assert_eq!(index.fields_ids_map(&rtxn).unwrap().len(), 5);
+        // the value is 7 because there is `[id, name, age, country, _geo, _geo.lng, _geo.lat]`
+        assert_eq!(index.fields_ids_map(&rtxn).unwrap().len(), 7);
 
         assert!(index.words_fst(&rtxn).unwrap().is_empty());
         assert!(index.words_prefixes_fst(&rtxn).unwrap().is_empty());

--- a/milli/src/update/delete_documents.rs
+++ b/milli/src/update/delete_documents.rs
@@ -647,7 +647,8 @@ mod tests {
         ]);
         let config = IndexerConfig::default();
         let indexing_config = IndexDocumentsConfig::default();
-        let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
         builder.add_documents(content).unwrap();
         builder.execute().unwrap();
 
@@ -681,7 +682,8 @@ mod tests {
 
         let config = IndexerConfig::default();
         let indexing_config = IndexDocumentsConfig::default();
-        let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
         builder.add_documents(content).unwrap();
         builder.execute().unwrap();
 
@@ -733,7 +735,8 @@ mod tests {
 
         let config = IndexerConfig::default();
         let indexing_config = IndexDocumentsConfig::default();
-        let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
         builder.add_documents(content).unwrap();
         builder.execute().unwrap();
 
@@ -790,7 +793,8 @@ mod tests {
 
         let indexing_config = IndexDocumentsConfig::default();
 
-        let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
         builder.add_documents(content).unwrap();
         builder.execute().unwrap();
 

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -59,7 +59,8 @@ pub fn setup_search_index_with_criteria(criteria: &[Criterion]) -> Index {
     let config = IndexerConfig { max_memory: Some(10 * 1024 * 1024), ..Default::default() };
     let indexing_config = IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
 
-    let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+    let mut builder =
+        IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
     let mut cursor = Cursor::new(Vec::new());
     let mut documents_builder = DocumentBatchBuilder::new(&mut cursor).unwrap();
     let reader = Cursor::new(CONTENT.as_bytes());

--- a/milli/tests/search/query_criteria.rs
+++ b/milli/tests/search/query_criteria.rs
@@ -390,7 +390,8 @@ fn criteria_ascdesc() {
     // index documents
     let config = IndexerConfig { max_memory: Some(10 * 1024 * 1024), ..Default::default() };
     let indexing_config = IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
-    let mut builder = IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ());
+    let mut builder =
+        IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
 
     let mut cursor = Cursor::new(Vec::new());
     let mut batch_builder = DocumentBatchBuilder::new(&mut cursor).unwrap();

--- a/milli/tests/search/typo_tolerance.rs
+++ b/milli/tests/search/typo_tolerance.rs
@@ -130,7 +130,8 @@ fn test_typo_disabled_on_word() {
     let mut txn = index.write_txn().unwrap();
     let config = IndexerConfig::default();
     let indexing_config = IndexDocumentsConfig::default();
-    let mut builder = IndexDocuments::new(&mut txn, &index, &config, indexing_config, |_| ());
+    let mut builder =
+        IndexDocuments::new(&mut txn, &index, &config, indexing_config, |_| ()).unwrap();
 
     builder.add_documents(documents).unwrap();
 


### PR DESCRIPTION
For the following document:
```json
{
  "id": 1,
  "person": {
    "name": "tamo",
    "age": 25,
  }
}
```
Suppose the user sets `person` as a filterable attribute. We need to store `person` in the filterable _obviously_. But we also need to keep track of `person.name` and `person.age` somewhere.
That’s where I changed a little bit the logic of the engine.

Currently, we have a function called `faceted_field` that returns the union of the filterable and sortable.
I renamed this function in `user_defined_faceted_field`. And now, when we finish indexing documents, we look at all the fields and see if they « match » a `user_defined_faceted_field`.
So in our case:
- does `id` match `person`: 🔴 
- does `person.name` match `person`: 🟢 
- does `person.age` match `person`: 🟢 

And thus, we insert in the database the following faceted fields: `person, person.name, person.age`.

The good thing about that solution is that we generate everything during the indexing phase, and then during the search, we can access our field without recomputing too much globbing.

-----

Now the bad thing is that I had to create a new db.

And if that was only one db, that would be ok, but actually, I need to do the same for the:
- Displayed attributes
- Attributes to retrieve
- Attributes to highlight
- Attribute to crop

@Kerollmops 
Do you think there is a better way to do it?
Apart from all the code, can we have a problem because we have too many dbs?