### PR TITLE
cli improvements

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -211,6 +211,8 @@ impl Performer for DocumentAddition {
 
         println!("parsing documents...");
 
+        let reader = BufReader::new(reader);
+
         let documents = match self.format {
             DocumentAdditionFormat::Csv => documents_from_csv(reader)?,
             DocumentAdditionFormat::Json => documents_from_json(reader)?,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,7 +23,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "Milli CLI", about = "A simple CLI to manipulate a milli index.")]
 struct Cli {
-    #[structopt(short, long)]
+    #[structopt(short, long, default_value = ".")]
     index_path: PathBuf,
     #[structopt(short = "s", long, default_value = "100GiB")]
     index_size: Byte,


### PR DESCRIPTION
a few improvements:
- use bufreader to load documents, so the loading of the document doesn't appear on flamegraphs
- set default db path to current directory so the `-i` flag can be omitted.

