### PR TITLE
Add a new error message when the filterableAttributes are empty

### DIFF
--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -39,12 +39,22 @@ impl<'a> std::error::Error for FilterError<'a> {}
 impl<'a> Display for FilterError<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AttributeNotFilterable { attribute, filterable } => write!(
-                f,
-                "Attribute `{}` is not filterable. Available filterable attributes are: `{}`.",
-                attribute,
-                filterable,
-            ),
+            Self::AttributeNotFilterable { attribute, filterable } => {
+                if filterable.is_empty() {
+                    write!(
+                        f,
+                        "Attribute `{}` is not filterable. This index does not have configured filterable attributes.",
+                        attribute,
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Attribute `{}` is not filterable. Available filterable attributes are: `{}`.",
+                        attribute,
+                        filterable,
+                    )
+                }
+            },
             Self::TooDeep => write!(f,
                 "Too many filter conditions, can't process more than {} filters.",
                 MAX_FILTER_DEPTH
@@ -554,13 +564,13 @@ mod tests {
         let filter = Filter::from_str("_geoRadius(42, 150, 10)").unwrap().unwrap();
         let error = filter.evaluate(&rtxn, &index).unwrap_err();
         assert!(error.to_string().starts_with(
-            "Attribute `_geo` is not filterable. Available filterable attributes are: ``."
+            "Attribute `_geo` is not filterable. This index does not have configured filterable attributes."
         ));
 
         let filter = Filter::from_str("dog = \"bernese mountain\"").unwrap().unwrap();
         let error = filter.evaluate(&rtxn, &index).unwrap_err();
         assert!(error.to_string().starts_with(
-            "Attribute `dog` is not filterable. Available filterable attributes are: ``."
+            "Attribute `dog` is not filterable. This index does not have configured filterable attributes."
         ));
         drop(rtxn);
 


### PR DESCRIPTION
Fixes https://github.com/meilisearch/meilisearch/issues/2140

Is there a good way to reduce de duplication here? Maybe adding a shared function? I don't know the best and idiomatic way to do that, I appreciate any tip!

Another doubt is related to the duplication of the calling:

```rs
// filter.rs:373
FilterError::AttributeNotFilterable {
    attribute,
    filterable: filterable_fields.into_iter().collect::<Vec<_>>().join(" "),
},
```

and

```rs
// filter.rs:424
return Err(point[0].as_external_error(FilterError::AttributeNotFilterable {
    attribute: "_geo",
    filterable: filterable_fields.into_iter().collect::<Vec<_>>().join(" "),
}))?;
```

I think we could make the `filterable_fields.into_iter().collect::<Vec<_>>().join(" ")` directly into the error handling like the sortable error. I made it into the last commit, if this is something to avoid, let me know and I can remove it :)