### PR TITLE
Set the cargo crate resolver to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["milli", "filter-parser", "http-ui", "benchmarks", "infos", "helpers", "cli"]
 default-members = ["milli"]
 


### PR DESCRIPTION
This PR updates the workspace resolver to v2. This should fix [the benchmarks](https://github.com/meilisearch/milli/runs/5558347765?check_suite_focus=true#step:8:184).
