### PR TITLE
set minimum word len for typos

### DIFF
--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -292,7 +292,7 @@ ranking rules settings to use the sort parameter at search time.",
             Self::UnknownInternalDocumentId { document_id } => {
                 write!(f, "An unknown internal document id have been used: `{}`.", document_id)
             }
-            Self::InvalidMinTypoWordSetting(one, two) => write!(f, "`minWordSizeForTypos` setting is invalid. `oneTypo` and `twoTypos` fields should be between `0` and `255`, and `twoTypos` should be greater or equals to `oneTypo` but found `oneTypo: {}` and twoTypos: {}`."", one, two),
+            Self::InvalidMinTypoWordSetting(one, two) => write!(f, "`minWordSizeForTypos` setting is invalid. `oneTypo` and `twoTypos` fields should be between `0` and `255`, and `twoTypos` should be greater or equals to `oneTypo` but found `oneTypo: {}` and twoTypos: {}`.", one, two),
         }
     }
 }

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -72,7 +72,7 @@ pub enum UserError {
     SerdeJson(serde_json::Error),
     SortError(SortError),
     UnknownInternalDocumentId { document_id: DocumentId },
-    InvalidMinTypoWordSetting(u8, u8),
+    InvalidMinTypoWordLenSetting(u8, u8),
 }
 
 impl From<io::Error> for Error {
@@ -292,7 +292,7 @@ ranking rules settings to use the sort parameter at search time.",
             Self::UnknownInternalDocumentId { document_id } => {
                 write!(f, "An unknown internal document id have been used: `{}`.", document_id)
             }
-            Self::InvalidMinTypoWordSetting(one, two) => write!(f, "`minWordSizeForTypos` setting is invalid. `oneTypo` and `twoTypos` fields should be between `0` and `255`, and `twoTypos` should be greater or equals to `oneTypo` but found `oneTypo: {}` and twoTypos: {}`.", one, two),
+            Self::InvalidMinTypoWordLenSetting(one, two) => write!(f, "`minWordSizeForTypos` setting is invalid. `oneTypo` and `twoTypos` fields should be between `0` and `255`, and `twoTypos` should be greater or equals to `oneTypo` but found `oneTypo: {}` and twoTypos: {}`.", one, two),
         }
     }
 }

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -292,7 +292,7 @@ ranking rules settings to use the sort parameter at search time.",
             Self::UnknownInternalDocumentId { document_id } => {
                 write!(f, "An unknown internal document id have been used: `{}`.", document_id)
             }
-            Self::InvalidMinTypoWordSetting(one, two) => write!(f, "Invalid settings for MinWordLenForTypo, expected 0 < 1-typo < 2-typos < 255, but found 1-typo: {} and 2-typo: {}", one, two),
+            Self::InvalidMinTypoWordSetting(one, two) => write!(f, "`minWordSizeForTypos` setting is invalid. `oneTypo` and `twoTypos` fields should be between `0` and `255`, and `twoTypos` should be greater or equals to `oneTypo` but found `oneTypo: {}` and twoTypos: {}`."", one, two),
         }
     }
 }

--- a/milli/src/error.rs
+++ b/milli/src/error.rs
@@ -72,6 +72,7 @@ pub enum UserError {
     SerdeJson(serde_json::Error),
     SortError(SortError),
     UnknownInternalDocumentId { document_id: DocumentId },
+    InvalidMinTypoWordSetting(u8, u8),
 }
 
 impl From<io::Error> for Error {
@@ -291,6 +292,7 @@ ranking rules settings to use the sort parameter at search time.",
             Self::UnknownInternalDocumentId { document_id } => {
                 write!(f, "An unknown internal document id have been used: `{}`.", document_id)
             }
+            Self::InvalidMinTypoWordSetting(one, two) => write!(f, "Invalid settings for MinWordLenForTypo, expected 0 < 1-typo < 2-typos < 255, but found 1-typo: {} and 2-typo: {}", one, two),
         }
     }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -937,6 +937,7 @@ pub(crate) mod tests {
     use maplit::btreemap;
     use tempfile::TempDir;
 
+    use crate::index::{DEFAULT_MIN_WORD_LEN_1_TYPO, DEFAULT_MIN_WORD_LEN_2_TYPOS};
     use crate::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig};
     use crate::Index;
 
@@ -1063,5 +1064,23 @@ pub(crate) mod tests {
 
         let txn = index.read_txn().unwrap();
         assert!(!index.authorize_typos(&txn).unwrap());
+    }
+
+    #[test]
+    fn set_min_word_len_for_typos() {
+        let index = TempIndex::new();
+        let mut txn = index.write_txn().unwrap();
+
+        assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_1_TYPO);
+        assert_eq!(index.min_word_len_2_typo(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_2_TYPOS);
+
+        index.put_min_word_len_1_typo(&mut txn, 3).unwrap();
+        index.put_min_word_len_2_typo(&mut txn, 15).unwrap();
+
+        txn.commit().unwrap();
+
+        let txn = index.read_txn().unwrap();
+        assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), 3);
+        assert_eq!(index.min_word_len_2_typo(&txn).unwrap(), 15);
     }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -910,7 +910,7 @@ impl Index {
         Ok(())
     }
 
-    pub fn min_word_len_2_typo(&self, txn: &RoTxn) -> heed::Result<u8> {
+    pub fn min_word_len_2_typos(&self, txn: &RoTxn) -> heed::Result<u8> {
         // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
         // identify 0 as being false, and anything else as true. The absence of a value is true,
         // because by default, we authorize typos.
@@ -920,7 +920,7 @@ impl Index {
             .unwrap_or(DEFAULT_MIN_WORD_LEN_2_TYPOS))
     }
 
-    pub(crate) fn put_min_word_len_2_typo(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
+    pub(crate) fn put_min_word_len_2_typos(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
         // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
         // identify 0 as being false, and anything else as true. The absence of a value is true,
         // because by default, we authorize typos.
@@ -1072,15 +1072,15 @@ pub(crate) mod tests {
         let mut txn = index.write_txn().unwrap();
 
         assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_1_TYPO);
-        assert_eq!(index.min_word_len_2_typo(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_2_TYPOS);
+        assert_eq!(index.min_word_len_2_typos(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_2_TYPOS);
 
         index.put_min_word_len_1_typo(&mut txn, 3).unwrap();
-        index.put_min_word_len_2_typo(&mut txn, 15).unwrap();
+        index.put_min_word_len_2_typos(&mut txn, 15).unwrap();
 
         txn.commit().unwrap();
 
         let txn = index.read_txn().unwrap();
         assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), 3);
-        assert_eq!(index.min_word_len_2_typo(&txn).unwrap(), 15);
+        assert_eq!(index.min_word_len_2_typos(&txn).unwrap(), 15);
     }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -23,6 +23,9 @@ use crate::{
     Search, StrBEU32Codec, StrStrU8Codec, BEU32,
 };
 
+pub const DEFAULT_MIN_WORD_LEN_1_TYPO: u8 = 5;
+pub const DEFAULT_MIN_WORD_LEN_2_TYPOS: u8 = 9;
+
 pub mod main_key {
     pub const CRITERIA_KEY: &str = "criteria";
     pub const DISPLAYED_FIELDS_KEY: &str = "displayed-fields";
@@ -47,6 +50,8 @@ pub mod main_key {
     pub const CREATED_AT_KEY: &str = "created-at";
     pub const UPDATED_AT_KEY: &str = "updated-at";
     pub const AUTHORIZE_TYPOS: &str = "authorize-typos";
+    pub const ONE_TYPO_WORD_LEN: &str = "one-typo-word-len";
+    pub const TWO_TYPOS_WORD_LEN: &str = "two-typos-word-len";
 }
 
 pub mod db_name {
@@ -884,6 +889,42 @@ impl Index {
         // because by default, we authorize typos.
         self.main.put::<_, Str, OwnedType<u8>>(txn, main_key::AUTHORIZE_TYPOS, &(flag as u8))?;
 
+        Ok(())
+    }
+
+    pub fn min_word_len_1_typo(&self, txn: &RoTxn) -> heed::Result<u8> {
+        // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
+        // identify 0 as being false, and anything else as true. The absence of a value is true,
+        // because by default, we authorize typos.
+        Ok(self
+            .main
+            .get::<_, Str, OwnedType<u8>>(txn, main_key::ONE_TYPO_WORD_LEN)?
+            .unwrap_or(DEFAULT_MIN_WORD_LEN_1_TYPO))
+    }
+
+    pub(crate) fn put_min_word_len_1_typo(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
+        // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
+        // identify 0 as being false, and anything else as true. The absence of a value is true,
+        // because by default, we authorize typos.
+        self.main.put::<_, Str, OwnedType<u8>>(txn, main_key::ONE_TYPO_WORD_LEN, &val)?;
+        Ok(())
+    }
+
+    pub fn min_word_len_2_typo(&self, txn: &RoTxn) -> heed::Result<u8> {
+        // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
+        // identify 0 as being false, and anything else as true. The absence of a value is true,
+        // because by default, we authorize typos.
+        Ok(self
+            .main
+            .get::<_, Str, OwnedType<u8>>(txn, main_key::TWO_TYPOS_WORD_LEN)?
+            .unwrap_or(DEFAULT_MIN_WORD_LEN_2_TYPOS))
+    }
+
+    pub(crate) fn put_min_word_len_2_typo(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
+        // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
+        // identify 0 as being false, and anything else as true. The absence of a value is true,
+        // because by default, we authorize typos.
+        self.main.put::<_, Str, OwnedType<u8>>(txn, main_key::TWO_TYPOS_WORD_LEN, &val)?;
         Ok(())
     }
 }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -23,8 +23,8 @@ use crate::{
     Search, StrBEU32Codec, StrStrU8Codec, BEU32,
 };
 
-pub const DEFAULT_MIN_WORD_LEN_1_TYPO: u8 = 5;
-pub const DEFAULT_MIN_WORD_LEN_2_TYPOS: u8 = 9;
+pub const DEFAULT_MIN_WORD_LEN_ONE_TYPO: u8 = 5;
+pub const DEFAULT_MIN_WORD_LEN_TWO_TYPOS: u8 = 9;
 
 pub mod main_key {
     pub const CRITERIA_KEY: &str = "criteria";
@@ -892,17 +892,17 @@ impl Index {
         Ok(())
     }
 
-    pub fn min_word_len_1_typo(&self, txn: &RoTxn) -> heed::Result<u8> {
+    pub fn min_word_len_one_typo(&self, txn: &RoTxn) -> heed::Result<u8> {
         // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
         // identify 0 as being false, and anything else as true. The absence of a value is true,
         // because by default, we authorize typos.
         Ok(self
             .main
             .get::<_, Str, OwnedType<u8>>(txn, main_key::ONE_TYPO_WORD_LEN)?
-            .unwrap_or(DEFAULT_MIN_WORD_LEN_1_TYPO))
+            .unwrap_or(DEFAULT_MIN_WORD_LEN_ONE_TYPO))
     }
 
-    pub(crate) fn put_min_word_len_1_typo(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
+    pub(crate) fn put_min_word_len_one_typo(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
         // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
         // identify 0 as being false, and anything else as true. The absence of a value is true,
         // because by default, we authorize typos.
@@ -910,17 +910,17 @@ impl Index {
         Ok(())
     }
 
-    pub fn min_word_len_2_typos(&self, txn: &RoTxn) -> heed::Result<u8> {
+    pub fn min_word_len_two_typos(&self, txn: &RoTxn) -> heed::Result<u8> {
         // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
         // identify 0 as being false, and anything else as true. The absence of a value is true,
         // because by default, we authorize typos.
         Ok(self
             .main
             .get::<_, Str, OwnedType<u8>>(txn, main_key::TWO_TYPOS_WORD_LEN)?
-            .unwrap_or(DEFAULT_MIN_WORD_LEN_2_TYPOS))
+            .unwrap_or(DEFAULT_MIN_WORD_LEN_TWO_TYPOS))
     }
 
-    pub(crate) fn put_min_word_len_2_typos(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
+    pub(crate) fn put_min_word_len_two_typos(&self, txn: &mut RwTxn, val: u8) -> heed::Result<()> {
         // It is not possible to put a bool in heed with OwnedType, so we put a u8 instead. We
         // identify 0 as being false, and anything else as true. The absence of a value is true,
         // because by default, we authorize typos.
@@ -937,7 +937,7 @@ pub(crate) mod tests {
     use maplit::btreemap;
     use tempfile::TempDir;
 
-    use crate::index::{DEFAULT_MIN_WORD_LEN_1_TYPO, DEFAULT_MIN_WORD_LEN_2_TYPOS};
+    use crate::index::{DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS};
     use crate::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig};
     use crate::Index;
 
@@ -1071,16 +1071,16 @@ pub(crate) mod tests {
         let index = TempIndex::new();
         let mut txn = index.write_txn().unwrap();
 
-        assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_1_TYPO);
-        assert_eq!(index.min_word_len_2_typos(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_2_TYPOS);
+        assert_eq!(index.min_word_len_one_typo(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_ONE_TYPO);
+        assert_eq!(index.min_word_len_two_typos(&txn).unwrap(), DEFAULT_MIN_WORD_LEN_TWO_TYPOS);
 
-        index.put_min_word_len_1_typo(&mut txn, 3).unwrap();
-        index.put_min_word_len_2_typos(&mut txn, 15).unwrap();
+        index.put_min_word_len_one_typo(&mut txn, 3).unwrap();
+        index.put_min_word_len_two_typos(&mut txn, 15).unwrap();
 
         txn.commit().unwrap();
 
         let txn = index.read_txn().unwrap();
-        assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), 3);
-        assert_eq!(index.min_word_len_2_typos(&txn).unwrap(), 15);
+        assert_eq!(index.min_word_len_one_typo(&txn).unwrap(), 3);
+        assert_eq!(index.min_word_len_two_typos(&txn).unwrap(), 15);
     }
 }

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -333,12 +333,12 @@ pub fn word_derivations<'c>(
                         // in the case the typo is on the first letter, we know the number of typo
                         // is two
                         if get_first(found_word) != get_first(word) {
-                            derived_words.push((word.to_string(), 2));
+                            derived_words.push((found_word.to_string(), 2));
                         } else {
                             // Else, we know that it is the second dfa that matched and compute the
                             // correct distance
                             let d = second_dfa.distance((state.1).0);
-                            derived_words.push((word.to_string(), d.to_u8()));
+                            derived_words.push((found_word.to_string(), d.to_u8()));
                         }
                     }
                 }

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -398,4 +398,67 @@ mod test {
         search.authorize_typos(true);
         assert!(!search.is_typo_authorized().unwrap());
     }
+
+    #[test]
+    fn test_one_typos_tolerance() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("zealend", false, 1, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[("zealand".to_string(), 1)]);
+    }
+
+    #[test]
+    fn test_one_typos_first_letter() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("sealand", false, 1, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[]);
+    }
+
+    #[test]
+    fn test_two_typos_tolerance() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("zealemd", false, 2, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[("zealand".to_string(), 2)]);
+    }
+
+    #[test]
+    fn test_two_typos_first_letter() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("sealand", false, 2, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[("zealand".to_string(), 2)]);
+    }
+
+    #[test]
+    fn test_prefix() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("ze", true, 0, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[("zealand".to_string(), 0)]);
+    }
+
+    #[test]
+    fn test_bad_prefix() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("se", true, 0, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[]);
+    }
+
+    #[test]
+    fn test_prefix_with_typo() {
+        let fst = fst::Set::from_iter(["zealand"].iter()).unwrap().map_data(Cow::Owned).unwrap();
+        let mut cache = HashMap::new();
+        let found = word_derivations("zae", true, 1, &fst, &mut cache).unwrap();
+
+        assert_eq!(found, &[("zealand".to_string(), 1)]);
+    }
 }

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -564,6 +564,8 @@ mod test {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
+    use crate::index::{DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS};
+
     use super::*;
 
     #[derive(Debug)]
@@ -602,7 +604,7 @@ mod test {
         }
 
         fn min_word_len_for_typo(&self) -> heed::Result<(u8, u8)> {
-            Ok((5, 9))
+            Ok((DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS))
         }
     }
 

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -264,6 +264,7 @@ fn split_best_frequency(ctx: &impl Context, word: &str) -> heed::Result<Option<O
     Ok(best.map(|(_, left, right)| Operation::Phrase(vec![left.to_string(), right.to_string()])))
 }
 
+#[derive(Clone)]
 pub struct TypoConfig {
     pub max_typos: u8,
     pub word_len_1_typo: u8,
@@ -1218,5 +1219,25 @@ mod test {
             TestContext::default().build(false, false, Some(2), tokens).unwrap().unwrap();
 
         assert_eq!(expected, query_tree);
+    }
+
+    #[test]
+    fn test_min_word_len_typo() {
+        let config = TypoConfig { max_typos: 2, word_len_1_typo: 5, word_len_2_typo: 7 };
+
+        assert_eq!(
+            typos("hello".to_string(), true, config.clone()),
+            QueryKind::Tolerant { typo: 1, word: "hello".to_string() }
+        );
+
+        assert_eq!(
+            typos("hell".to_string(), true, config.clone()),
+            QueryKind::exact("hell".to_string())
+        );
+
+        assert_eq!(
+            typos("verylongword".to_string(), true, config.clone()),
+            QueryKind::Tolerant { typo: 2, word: "verylongword".to_string() }
+        );
     }
 }

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -183,7 +183,7 @@ impl<'a> Context for QueryTreeBuilder<'a> {
 
     fn min_word_len_for_typo(&self) -> heed::Result<(u8, u8)> {
         let one = self.index.min_word_len_1_typo(&self.rtxn)?;
-        let two = self.index.min_word_len_2_typo(&self.rtxn)?;
+        let two = self.index.min_word_len_2_typos(&self.rtxn)?;
         Ok((one, two))
     }
 }

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -276,9 +276,9 @@ pub struct TypoConfig {
 fn typos(word: String, authorize_typos: bool, config: TypoConfig) -> QueryKind {
     if authorize_typos {
         let count = word.chars().count().min(u8::MAX as usize) as u8;
-        if (0..config.word_len_one_typo).contains(&count) {
+        if count < config.word_len_one_typo {
             QueryKind::exact(word)
-        } else if (config.word_len_one_typo..config.word_len_two_typo).contains(&count) {
+        } else if count < config.word_len_two_typo {
             QueryKind::tolerant(1.min(config.max_typos), word)
         } else {
             QueryKind::tolerant(2.min(config.max_typos), word)

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -564,9 +564,8 @@ mod test {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
-    use crate::index::{DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS};
-
     use super::*;
+    use crate::index::{DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS};
 
     #[derive(Debug)]
     struct TestContext {

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -501,11 +501,11 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
                     return Err(UserError::InvalidMinTypoWordSetting(*one, *two).into());
                 } else {
                     self.index.put_min_word_len_1_typo(&mut self.wtxn, *one)?;
-                    self.index.put_min_word_len_2_typo(&mut self.wtxn, *two)?;
+                    self.index.put_min_word_len_2_typos(&mut self.wtxn, *two)?;
                 }
             }
             (Setting::Set(one), _) => {
-                let two = self.index.min_word_len_2_typo(&self.wtxn)?;
+                let two = self.index.min_word_len_2_typos(&self.wtxn)?;
                 if *one > two {
                     return Err(UserError::InvalidMinTypoWordSetting(*one, two).into());
                 } else {
@@ -517,7 +517,7 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
                 if one > *two {
                     return Err(UserError::InvalidMinTypoWordSetting(one, *two).into());
                 } else {
-                    self.index.put_min_word_len_2_typo(&mut self.wtxn, *two)?;
+                    self.index.put_min_word_len_2_typos(&mut self.wtxn, *two)?;
                 }
             }
             _ => (),
@@ -1304,7 +1304,7 @@ mod tests {
         let txn = index.read_txn().unwrap();
 
         assert_eq!(index.min_word_len_1_typo(&txn).unwrap(), 8);
-        assert_eq!(index.min_word_len_2_typo(&txn).unwrap(), 8);
+        assert_eq!(index.min_word_len_2_typos(&txn).unwrap(), 8);
     }
 
     #[test]

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -14,7 +14,7 @@ use crate::update::index_documents::IndexDocumentsMethod;
 use crate::update::{ClearDocuments, IndexDocuments, UpdateIndexingStep};
 use crate::{FieldsIdsMap, Index, Result};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum Setting<T> {
     Set(T),
     Reset,
@@ -495,29 +495,29 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
     }
 
     fn update_min_typo_word_len(&mut self) -> Result<()> {
-        match (&self.min_word_len_one_typo, &self.min_word_len_two_typos) {
+        match (self.min_word_len_one_typo, self.min_word_len_two_typos) {
             (Setting::Set(one), Setting::Set(two)) => {
                 if one > two {
-                    return Err(UserError::InvalidMinTypoWordLenSetting(*one, *two).into());
+                    return Err(UserError::InvalidMinTypoWordLenSetting(one, two).into());
                 } else {
-                    self.index.put_min_word_len_one_typo(&mut self.wtxn, *one)?;
-                    self.index.put_min_word_len_two_typos(&mut self.wtxn, *two)?;
+                    self.index.put_min_word_len_one_typo(&mut self.wtxn, one)?;
+                    self.index.put_min_word_len_two_typos(&mut self.wtxn, two)?;
                 }
             }
             (Setting::Set(one), _) => {
                 let two = self.index.min_word_len_two_typos(&self.wtxn)?;
-                if *one > two {
-                    return Err(UserError::InvalidMinTypoWordLenSetting(*one, two).into());
+                if one > two {
+                    return Err(UserError::InvalidMinTypoWordLenSetting(one, two).into());
                 } else {
-                    self.index.put_min_word_len_one_typo(&mut self.wtxn, *one)?;
+                    self.index.put_min_word_len_one_typo(&mut self.wtxn, one)?;
                 }
             }
             (_, Setting::Set(two)) => {
                 let one = self.index.min_word_len_one_typo(&self.wtxn)?;
-                if one > *two {
-                    return Err(UserError::InvalidMinTypoWordLenSetting(one, *two).into());
+                if one > two {
+                    return Err(UserError::InvalidMinTypoWordLenSetting(one, two).into());
                 } else {
-                    self.index.put_min_word_len_two_typos(&mut self.wtxn, *two)?;
+                    self.index.put_min_word_len_two_typos(&mut self.wtxn, two)?;
                 }
             }
             _ => (),

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -498,7 +498,7 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
         match (&self.min_1_typo_word_len, &self.min_2_typos_word_len) {
             (Setting::Set(one), Setting::Set(two)) => {
                 if one > two {
-                    return Err(UserError::InvalidMinTypoWordSetting(*one, *two).into());
+                    return Err(UserError::InvalidMinTypoWordLenSetting(*one, *two).into());
                 } else {
                     self.index.put_min_word_len_1_typo(&mut self.wtxn, *one)?;
                     self.index.put_min_word_len_2_typos(&mut self.wtxn, *two)?;
@@ -507,7 +507,7 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
             (Setting::Set(one), _) => {
                 let two = self.index.min_word_len_2_typos(&self.wtxn)?;
                 if *one > two {
-                    return Err(UserError::InvalidMinTypoWordSetting(*one, two).into());
+                    return Err(UserError::InvalidMinTypoWordLenSetting(*one, two).into());
                 } else {
                     self.index.put_min_word_len_1_typo(&mut self.wtxn, *one)?;
                 }
@@ -515,7 +515,7 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
             (_, Setting::Set(two)) => {
                 let one = self.index.min_word_len_1_typo(&self.wtxn)?;
                 if one > *two {
-                    return Err(UserError::InvalidMinTypoWordSetting(one, *two).into());
+                    return Err(UserError::InvalidMinTypoWordLenSetting(one, *two).into());
                 } else {
                     self.index.put_min_word_len_2_typos(&mut self.wtxn, *two)?;
                 }

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -16,6 +16,7 @@ mod distinct;
 mod filters;
 mod query_criteria;
 mod sort;
+mod typo_tolerance;
 
 pub const TEST_QUERY: &'static str = "hello world america";
 

--- a/milli/tests/search/typo_tolerance.rs
+++ b/milli/tests/search/typo_tolerance.rs
@@ -1,0 +1,97 @@
+use milli::{
+    update::{IndexerConfig, Settings},
+    Criterion, Search,
+};
+use Criterion::*;
+
+#[test]
+fn test_typo_tolerance_one_typo() {
+    let criteria = [Typo];
+    let index = super::setup_search_index_with_criteria(&criteria);
+
+    // basic typo search with default typo settings
+    {
+        let txn = index.read_txn().unwrap();
+
+        let mut search = Search::new(&txn, &index);
+        search.query("zeal");
+        search.limit(10);
+        search.authorize_typos(true);
+        search.optional_words(true);
+
+        let result = search.execute().unwrap();
+        assert_eq!(result.documents_ids.len(), 1);
+
+        let mut search = Search::new(&txn, &index);
+        search.query("zean");
+        search.limit(10);
+        search.authorize_typos(true);
+        search.optional_words(true);
+
+        let result = search.execute().unwrap();
+        assert_eq!(result.documents_ids.len(), 0);
+    }
+
+    let mut txn = index.write_txn().unwrap();
+
+    let config = IndexerConfig::default();
+    let mut builder = Settings::new(&mut txn, &index, &config);
+    builder.set_min_word_len_one_typo(4);
+    builder.execute(|_| ()).unwrap();
+
+    // typo is now supported for 4 letters words
+    let mut search = Search::new(&txn, &index);
+    search.query("zean");
+    search.limit(10);
+    search.authorize_typos(true);
+    search.optional_words(true);
+
+    let result = search.execute().unwrap();
+    assert_eq!(result.documents_ids.len(), 1);
+}
+
+#[test]
+fn test_typo_tolerance_two_typo() {
+    let criteria = [Typo];
+    let index = super::setup_search_index_with_criteria(&criteria);
+
+    // basic typo search with default typo settings
+    {
+        let txn = index.read_txn().unwrap();
+
+        let mut search = Search::new(&txn, &index);
+        search.query("zealand");
+        search.limit(10);
+        search.authorize_typos(true);
+        search.optional_words(true);
+
+        let result = search.execute().unwrap();
+        assert_eq!(result.documents_ids.len(), 1);
+
+        let mut search = Search::new(&txn, &index);
+        search.query("zealemd");
+        search.limit(10);
+        search.authorize_typos(true);
+        search.optional_words(true);
+
+        let result = search.execute().unwrap();
+        assert_eq!(result.documents_ids.len(), 0);
+    }
+
+    let mut txn = index.write_txn().unwrap();
+
+    let config = IndexerConfig::default();
+    let mut builder = Settings::new(&mut txn, &index, &config);
+    builder.set_min_word_len_two_typos(7);
+    builder.execute(|_| ()).unwrap();
+
+    // typo is now supported for 4 letters words
+    let mut search = Search::new(&txn, &index);
+    search.query("zealemd");
+    search.limit(10);
+    search.authorize_typos(true);
+    search.optional_words(true);
+
+    let result = search.execute().unwrap();
+    assert_eq!(result.documents_ids.len(), 1);
+}

--- a/milli/tests/search/typo_tolerance.rs
+++ b/milli/tests/search/typo_tolerance.rs
@@ -1,7 +1,5 @@
-use milli::{
-    update::{IndexerConfig, Settings},
-    Criterion, Search,
-};
+use milli::update::{IndexerConfig, Settings};
+use milli::{Criterion, Search};
 use Criterion::*;
 
 #[test]


### PR DESCRIPTION
this PR allows the configuration on the minimum word length for typos.

The default values are the same as previously.

## steps
- [x] introduce settings for the minimum word length for 1 and 2 typos
- [x] update the settings update flow to set this setting
- [x] create a structure `TypoConfig` to configure typo tolerance in the query builder
- [x] in `typo`, use the configuration to create the appropriate query tree node.
- [x] extend `Context` to return the setting for minimum word length for typos
- [x] return correct error message for wrong settings.
- [x] merge #469 