### PR TITLE
Bump tokenizer

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -18,7 +18,7 @@ grenad = { version = "0.4.1", default-features = false, features = ["tempfile"] 
 geoutils = "0.4.1"
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.1", default-features = false, features = ["lmdb", "sync-read-txn"] }
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.7" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.9" }
 memmap2 = "0.5.3"
 obkv = "0.2.0"
 once_cell = "1.10.0"


### PR DESCRIPTION
This PR bump the tokenizer in v0.2.9 which fixes an issue we had with lindera where reqwest was used with openssl (which was breaking our benchmarks).