### PR TITLE
Rollback meilisearch-tokenizer version

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -18,7 +18,7 @@ grenad = { version = "0.4.1", default-features = false, features = ["tempfile"] 
 geoutils = "0.4.1"
 heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.1", default-features = false, features = ["lmdb", "sync-read-txn"] }
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
-meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.8" }
+meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", tag = "v0.2.7" }
 memmap2 = "0.5.3"
 obkv = "0.2.0"
 once_cell = "1.10.0"


### PR DESCRIPTION
Lindera often fails to download some data from google drive we can’t compile consistently meilisearch / milli.
We can’t bump to the latest version (that moved out of google drive) either because lindera uses reqwest with openssl with no way of configuring it our benchmarks were not able to run. The latter issue should be fixed by https://github.com/lindera-morphology/lindera/pull/164.