### PR TITLE
Increase benchmarks (push) CI timeout

### DIFF
--- a/.github/workflows/push_benchmarks_indexing.yml
+++ b/.github/workflows/push_benchmarks_indexing.yml
@@ -13,6 +13,7 @@ jobs:
   benchmarks:
     name: Run and upload benchmarks
     runs-on: benchmarks
+    timeout-minutes: 4320 # 72h
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This PR fixes the fact that the benchmarks CI on push were [canceled by GitHub](https://github.com/meilisearch/milli/actions/runs/2028844132) because they reached the default timeout of 6h. This PR changes the timeout to 72h, the same setting as the manually triggered benchmark one.