### PR TITLE
Enforce labelling for the PRs

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -1,18 +1,21 @@
 name-template: 'Milli v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
-  - 'skip-changelog'
+  - 'skip changelog'
 version-resolver:
   minor:
     labels:
-      - 'breaking-change'
+      - 'DB breaking'
+      - 'API breaking'
   default: patch
 categories:
-  - title: 'Breaking changes ⚠️'
-    label: 'breaking-change'
+  - title: 'API breaking'
+    label: 'API breaking'
+  - title: 'DB breaking'
+    label: 'DB breaking'
+  - title: 'Changes'
+    label: 'no breaking'
 template: |
-  ## Changes
-
   $CHANGES
 
   Thanks again to $CONTRIBUTORS! 🎉

--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,0 +1,14 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+jobs:
+  enforce-label:
+    name: Specify breaking
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: 'no breaking,DB breaking,API breaking,skip changelog'


### PR DESCRIPTION
- Enforce one of the following labels to make the CI pass: `no breaking`, `DB breaking`, `API breaking` (milli API, not the Meilisearch API of course), or `skip changelog`. This new CI is now `Required` in the GitHub settings for merging a PR.
- Adapt the release drafter to these new labels
- rename `skip-changelog` into `skip changelog` according to the new label name