### PR TITLE
remove the unused key warning

### DIFF
--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"
-author = ["Tamo tamo@meilisearch.com"]
-repository = "https://github.com/irevoire/flatten-serde-json"
-keywords = ["json", "flatten"]
-categories = ["command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
When I copy-pasted my flatten crate I forgot to remove the key use to publish the package and that throw a warning.