### PR TITLE
v0.26.2 release: includes the typo-tolerance fix

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Replaces https://github.com/meilisearch/milli/pull/501 due to a bad manipulation of branches on my side

The branch `release-v0.26.2` is starting from the `v0.26.1` tag and not from the latest commit on `main`