### PR TITLE
v0.26.3 release: normalizes exact word

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.1.0"
+version = "0.26.3"
 edition = "2018"
 publish = false
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filter-parser"
-version = "0.1.0"
+version = "0.26.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatten-serde-json"
-version = "0.1.0"
+version = "0.26.3"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-depth-checker"
-version = "0.1.0"
+version = "0.26.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -1337,32 +1337,34 @@ mod tests {
 
         let mut wtxn = index.write_txn().unwrap();
         let mut builder = update::Settings::new(&mut wtxn, &index, &config);
-        builder.set_primary_key("nested.id".to_owned());
+        builder.set_primary_key("complex.nested.id".to_owned());
         builder.execute(|_| ()).unwrap();
         wtxn.commit().unwrap();
 
         let mut wtxn = index.write_txn().unwrap();
         let content = documents!([
             {
-                "nested": {
-                    "id": 0,
+                "complex": {
+                    "nested": {
+                        "id": 0,
+                    },
                 },
                 "title": "The zeroth document",
             },
             {
-                "nested": {
+                "complex.nested": {
                     "id": 1,
                 },
                 "title": "The first document",
             },
             {
-                "nested": {
-                    "id": 2,
+                "complex": {
+                    "nested.id": 2,
                 },
                 "title": "The second document",
             },
             {
-                "nested.id": 3,
+                "complex.nested.id": 3,
                 "title": "The third document",
             },
         ]);

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1461,4 +1461,22 @@ mod tests {
         builder.set_min_word_len_two_typos(7);
         assert!(builder.execute(|_| ()).is_err());
     }
+
+    #[test]
+    fn update_exact_words_normalization() {
+        let index = TempIndex::new();
+        let config = IndexerConfig::default();
+
+        // Set the genres setting
+        let mut txn = index.write_txn().unwrap();
+        let mut builder = Settings::new(&mut txn, &index, &config);
+
+        let words = btreeset! { S("Ab"), S("ac") };
+        builder.set_exact_words(words);
+        assert!(builder.execute(|_| ()).is_ok());
+        let exact_words = index.exact_words(&txn).unwrap();
+        for word in exact_words.into_fst().stream().into_str_vec().unwrap() {
+            assert!(word.0 == "ac" || word.0 == "ab");
+        }
+    }
 }


### PR DESCRIPTION
`release-v0.26.3` is originated from `v0.26.2` and not from `main`

Add the commits of
- https://github.com/meilisearch/milli/pull/505
- https://github.com/meilisearch/milli/pull/514

And update the version in every concerned files

The tag `v0.26.3` will be created once this PR is merged and will be done on the `release-v0.26.3` branch