### PR TITLE
Update version in every workspace

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.1.0"
+version = "0.27.0"
 edition = "2018"
 publish = false
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cli"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2018"
 description = "A CLI to interact with a milli index"
+publish = false
 
 [dependencies]
 indicatif = "0.16.2"

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "filter-parser"
-version = "0.1.0"
+version = "0.27.0"
 edition = "2021"
 description = "The parser for the Meilisearch filter syntax"
+publish = false
 
 [dependencies]
 nom = "7.1.0"

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "flatten-serde-json"
-version = "0.1.0"
+version = "0.27.0"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"
+publish = false
 
 [dependencies]
 serde_json = "1.0"

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "helpers"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 description = "A small tool to do operations on the database"
+publish = false
 
 [dependencies]
 anyhow = "1.0.56"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 anyhow = "1.0.56"

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "infos"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 anyhow = "1.0.56"

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "json-depth-checker"
-version = "0.1.0"
+version = "0.27.0"
 edition = "2021"
 description = "A library that indicates if a JSON must be flattened"
+publish = false
 
 [dependencies]
 serde_json = "1.0"

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.26.1"
+version = "0.27.0"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Checked with @Kerollmops 

- Update the version into every workspace (the current version is v0.27.0, but I forgot to update it for the previous release)
- add `publish = false` except in `milli` workspace.
