### PR TITLE
Release v0.26.4: returns facets even when there is no value associated to it + bug fix during indexation + bug fix on typo-tolerance

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2018"
 publish = false
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filter-parser"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatten-serde-json"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.26.3"
+version = "0.26.4"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.26.3"
+version = "0.26.4"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.26.3"
+version = "0.26.4"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-depth-checker"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.26.3"
+version = "0.26.4"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 

--- a/milli/src/search/facet/facet_distribution.rs
+++ b/milli/src/search/facet/facet_distribution.rs
@@ -243,9 +243,7 @@ impl<'a> FacetDistribution<'a> {
         for (fid, name) in fields_ids_map.iter() {
             if crate::is_faceted(name, &fields) {
                 let values = self.facet_values(fid)?;
-                if !values.is_empty() {
-                    distribution.insert(name.to_string(), values);
-                }
+                distribution.insert(name.to_string(), values);
             }
         }
 

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -20,7 +20,8 @@ use typed_chunk::{write_typed_chunk_into_index, TypedChunk};
 pub use self::helpers::{
     as_cloneable_grenad, create_sorter, create_writer, fst_stream_into_hashset,
     fst_stream_into_vec, merge_cbo_roaring_bitmaps, merge_roaring_bitmaps,
-    sorter_into_lmdb_database, write_into_lmdb_database, writer_into_reader, ClonableMmap, MergeFn,
+    sorter_into_lmdb_database, valid_lmdb_key, write_into_lmdb_database, writer_into_reader,
+    ClonableMmap, MergeFn,
 };
 use self::helpers::{grenad_obkv_into_chunks, GrenadParameters};
 pub use self::transform::{Transform, TransformOutput};

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -1625,4 +1625,81 @@ mod tests {
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids.len(), 1);
     }
+
+    /// We try to index documents with words that are too long here,
+    /// it should not return any error.
+    #[test]
+    fn text_with_too_long_words() {
+        let path = tempfile::tempdir().unwrap();
+        let mut options = EnvOpenOptions::new();
+        options.map_size(10 * 1024 * 1024); // 10 MB
+        let index = Index::new(options, &path).unwrap();
+
+        let content = documents!([
+          {"id": 1, "title": "a".repeat(256) },
+          {"id": 2, "title": "b".repeat(512) },
+          {"id": 3, "title": format!("{} {}", "c".repeat(250), "d".repeat(250)) },
+        ]);
+
+        let mut wtxn = index.write_txn().unwrap();
+        let config = IndexerConfig::default();
+        let indexing_config = IndexDocumentsConfig::default();
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config.clone(), |_| ())
+                .unwrap();
+        builder.add_documents(content).unwrap();
+        builder.execute().unwrap();
+        wtxn.commit().unwrap();
+    }
+
+    #[test]
+    fn text_with_too_long_keys() {
+        let path = tempfile::tempdir().unwrap();
+        let mut options = EnvOpenOptions::new();
+        options.map_size(10 * 1024 * 1024); // 10 MB
+        let index = Index::new(options, &path).unwrap();
+        let script = "https://bug.example.com/meilisearch/milli.saml2?ROLE=Programmer-1337&SAMLRequest=Cy1ytcZT1Po%2L2IY2y9Unru8rgnW4qWfPiI0EpT7P8xjJV8PeQikRL%2E8D9A4pj9tmbymbQCQwGmGjPMK7qwXFPX4DH52JO2b7n6TXjuR7zkIFuYdzdY2rwRNBPgCL7ihclEm9zyIjKZQ%2JTqiwfXxWjnI0KEYQYHdwd6Q%2Fx%28BDLNsvmL54CCY2F4RWeRs4eqWfn%2EHqxlhreFzax4AiQ2tgOtV5thOaaWqrhZD%2Py70nuyZWNTKwciGI43AoHg6PThANsQ5rAY5amzN%2ufbs1swETUXlLZuOut5YGpYPZfY6STJWNp4QYSUOUXBZpdElYsH7UHZ7VhJycgyt%28aTK0GW6GbKne2tJM0hgSczOqndg6RFa9WsnSBi4zMcaEfYur4WlSsHDYInF9ROousKqVMZ6H8%2gbUissaLh1eXRGo8KEJbyEHbhVVKGD%28kx4cfKjx9fT3pkeDTdvDrVn25jIzi9wHyt9l1lWc8ICnCvXCVUPP%2BjBG4wILR29gMV9Ux2QOieQm2%2Fycybhr8sBGCl30mHC7blvWt%2T3mrCHQoS3VK49PZNPqBZO9C7vOjOWoszNkJx4QckWV%2FZFvbpzUUkiBiehr9F%2FvQSxz9lzv68GwbTu9fr638p%2FQM%3D&RelayState=https%3A%2F%example.bug.com%2Fde&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&Signature=AZFpkhFFII7PodiewTovaGnLQKUVZp0qOCCcBIUkJ6P5by3lE3Lldj9pKaFu4wz4j%2B015HEhDvF0LlAmwwES85vdGh%2FpD%2cIQPRUEjdCbQkQDd3dy1mMXbpXxSe4QYcv9Ni7tqNTQxekpO1gE7rtg6zC66EU55uM9aj9abGQ034Vly%2F6IJ08bvAq%2B%2FB9KruLstuiNWnlXTfNGsOxGLK7%2BXr94LTkat8m%2FMan6Qr95%2KeR5TmmqaQIE4N9H6o4TopT7mXr5CF2Z3";
+
+        // Create 200 documents with a long text
+        let content = {
+            let documents: Vec<_> = (0..200i32)
+                .into_iter()
+                .map(|i| serde_json::json!({ "id": i, "script": script }))
+                .collect();
+
+            let mut writer = std::io::Cursor::new(Vec::new());
+            let mut builder = crate::documents::DocumentBatchBuilder::new(&mut writer).unwrap();
+            let documents = serde_json::to_vec(&documents).unwrap();
+            builder.extend_from_json(std::io::Cursor::new(documents)).unwrap();
+            builder.finish().unwrap();
+            writer.set_position(0);
+            crate::documents::DocumentBatchReader::from_reader(writer).unwrap()
+        };
+
+        // Index those 200 long documents
+        let mut wtxn = index.write_txn().unwrap();
+        let config = IndexerConfig::default();
+        let indexing_config = IndexDocumentsConfig::default();
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config.clone(), |_| ())
+                .unwrap();
+        builder.add_documents(content).unwrap();
+        builder.execute().unwrap();
+
+        // Create one long document
+        let content = documents!([
+          {"id": 400, "script": script },
+        ]);
+
+        // Index this one long document
+        let config = IndexerConfig::default();
+        let indexing_config = IndexDocumentsConfig::default();
+        let mut builder =
+            IndexDocuments::new(&mut wtxn, &index, &config, indexing_config.clone(), |_| ())
+                .unwrap();
+        builder.add_documents(content).unwrap();
+        builder.execute().unwrap();
+
+        wtxn.commit().unwrap();
+    }
 }

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -126,9 +126,9 @@ impl<'a, 't, 'u, 'i> Settings<'a, 't, 'u, 'i> {
             primary_key: Setting::NotSet,
             authorize_typos: Setting::NotSet,
             exact_words: Setting::NotSet,
-            min_word_len_two_typos: Setting::Reset,
-            min_word_len_one_typo: Setting::Reset,
-            exact_attributes: Setting::Reset,
+            min_word_len_two_typos: Setting::NotSet,
+            min_word_len_one_typo: Setting::NotSet,
+            exact_attributes: Setting::NotSet,
             indexer_config,
         }
     }
@@ -1495,5 +1495,49 @@ mod tests {
         for word in exact_words.into_fst().stream().into_str_vec().unwrap() {
             assert!(word.0 == "ac" || word.0 == "ab");
         }
+    }
+
+    #[test]
+    fn test_correct_settings_init() {
+        let index = TempIndex::new();
+        let config = IndexerConfig::default();
+
+        // Set the genres setting
+        let mut txn = index.write_txn().unwrap();
+        let builder = Settings::new(&mut txn, &index, &config);
+        let Settings {
+            wtxn: _,
+            index: _,
+            indexer_config: _,
+            searchable_fields,
+            displayed_fields,
+            filterable_fields,
+            sortable_fields,
+            criteria,
+            stop_words,
+            distinct_field,
+            synonyms,
+            primary_key,
+            authorize_typos,
+            min_word_len_two_typos,
+            min_word_len_one_typo,
+            exact_words,
+            exact_attributes,
+        } = builder;
+
+        assert!(matches!(searchable_fields, Setting::NotSet));
+        assert!(matches!(displayed_fields, Setting::NotSet));
+        assert!(matches!(filterable_fields, Setting::NotSet));
+        assert!(matches!(sortable_fields, Setting::NotSet));
+        assert!(matches!(criteria, Setting::NotSet));
+        assert!(matches!(stop_words, Setting::NotSet));
+        assert!(matches!(distinct_field, Setting::NotSet));
+        assert!(matches!(synonyms, Setting::NotSet));
+        assert!(matches!(primary_key, Setting::NotSet));
+        assert!(matches!(authorize_typos, Setting::NotSet));
+        assert!(matches!(min_word_len_two_typos, Setting::NotSet));
+        assert!(matches!(min_word_len_one_typo, Setting::NotSet));
+        assert!(matches!(exact_words, Setting::NotSet));
+        assert!(matches!(exact_attributes, Setting::NotSet));
     }
 }

--- a/milli/src/update/word_prefix_docids.rs
+++ b/milli/src/update/word_prefix_docids.rs
@@ -5,7 +5,8 @@ use heed::types::{ByteSlice, Str};
 use heed::Database;
 
 use crate::update::index_documents::{
-    create_sorter, merge_roaring_bitmaps, sorter_into_lmdb_database, CursorClonableMmap, MergeFn,
+    create_sorter, merge_roaring_bitmaps, sorter_into_lmdb_database, valid_lmdb_key,
+    CursorClonableMmap, MergeFn,
 };
 use crate::{Result, RoaringBitmapCodec};
 
@@ -124,7 +125,9 @@ fn write_prefixes_in_sorter(
 ) -> Result<()> {
     for (key, data_slices) in prefixes.drain() {
         for data in data_slices {
-            sorter.insert(&key, data)?;
+            if valid_lmdb_key(&key) {
+                sorter.insert(&key, data)?;
+            }
         }
     }
 

--- a/milli/src/update/word_prefix_pair_proximity_docids.rs
+++ b/milli/src/update/word_prefix_pair_proximity_docids.rs
@@ -7,8 +7,8 @@ use log::debug;
 use slice_group_by::GroupBy;
 
 use crate::update::index_documents::{
-    create_sorter, merge_cbo_roaring_bitmaps, sorter_into_lmdb_database, CursorClonableMmap,
-    MergeFn,
+    create_sorter, merge_cbo_roaring_bitmaps, sorter_into_lmdb_database, valid_lmdb_key,
+    CursorClonableMmap, MergeFn,
 };
 use crate::{Index, Result, StrStrU8Codec};
 
@@ -188,7 +188,9 @@ fn write_prefixes_in_sorter(
 ) -> Result<()> {
     for (key, data_slices) in prefixes.drain() {
         for data in data_slices {
-            sorter.insert(&key, data)?;
+            if valid_lmdb_key(&key) {
+                sorter.insert(&key, data)?;
+            }
         }
     }
 

--- a/milli/src/update/words_prefix_position_docids.rs
+++ b/milli/src/update/words_prefix_position_docids.rs
@@ -11,8 +11,8 @@ use crate::error::SerializationError;
 use crate::heed_codec::StrBEU32Codec;
 use crate::index::main_key::WORDS_PREFIXES_FST_KEY;
 use crate::update::index_documents::{
-    create_sorter, merge_cbo_roaring_bitmaps, sorter_into_lmdb_database, CursorClonableMmap,
-    MergeFn,
+    create_sorter, merge_cbo_roaring_bitmaps, sorter_into_lmdb_database, valid_lmdb_key,
+    CursorClonableMmap, MergeFn,
 };
 use crate::{Index, Result};
 
@@ -167,7 +167,9 @@ fn write_prefixes_in_sorter(
 ) -> Result<()> {
     for (key, data_slices) in prefixes.drain() {
         for data in data_slices {
-            sorter.insert(&key, data)?;
+            if valid_lmdb_key(&key) {
+                sorter.insert(&key, data)?;
+            }
         }
     }
 

--- a/milli/tests/search/facet_distribution.rs
+++ b/milli/tests/search/facet_distribution.rs
@@ -1,0 +1,77 @@
+use std::io::Cursor;
+
+use big_s::S;
+use heed::EnvOpenOptions;
+use maplit::hashset;
+use milli::documents::{DocumentBatchBuilder, DocumentBatchReader};
+use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig, Settings};
+use milli::{FacetDistribution, Index};
+
+#[test]
+fn test_facet_distribution_with_no_facet_values() {
+    let path = tempfile::tempdir().unwrap();
+    let mut options = EnvOpenOptions::new();
+    options.map_size(10 * 1024 * 1024); // 10 MB
+    let index = Index::new(options, &path).unwrap();
+
+    let mut wtxn = index.write_txn().unwrap();
+    let config = IndexerConfig::default();
+    let mut builder = Settings::new(&mut wtxn, &index, &config);
+
+    builder.set_filterable_fields(hashset! {
+        S("genres"),
+        S("tags"),
+    });
+    builder.execute(|_| ()).unwrap();
+
+    // index documents
+    let config = IndexerConfig { max_memory: Some(10 * 1024 * 1024), ..Default::default() };
+    let indexing_config = IndexDocumentsConfig { autogenerate_docids: true, ..Default::default() };
+
+    let mut builder =
+        IndexDocuments::new(&mut wtxn, &index, &config, indexing_config, |_| ()).unwrap();
+    let mut cursor = Cursor::new(Vec::new());
+    let mut documents_builder = DocumentBatchBuilder::new(&mut cursor).unwrap();
+    let reader = Cursor::new(
+        r#"[
+        {
+            "id": 123,
+            "title": "What a week, hu...",
+            "genres": [],
+            "tags": ["blue"]
+        },
+        {
+            "id": 345,
+            "title": "I am the pig!",
+            "tags": ["red"]
+        }
+    ]"#,
+    );
+
+    for doc in serde_json::Deserializer::from_reader(reader).into_iter::<serde_json::Value>() {
+        let doc = Cursor::new(serde_json::to_vec(&doc.unwrap()).unwrap());
+        documents_builder.extend_from_json(doc).unwrap();
+    }
+
+    documents_builder.finish().unwrap();
+
+    cursor.set_position(0);
+
+    // index documents
+    let content = DocumentBatchReader::from_reader(cursor).unwrap();
+    builder.add_documents(content).unwrap();
+    builder.execute().unwrap();
+
+    wtxn.commit().unwrap();
+
+    let txn = index.read_txn().unwrap();
+    let mut distrib = FacetDistribution::new(&txn, &index);
+    distrib.facets(vec!["genres"]);
+    let result = distrib.execute().unwrap();
+    assert_eq!(result["genres"].len(), 0);
+
+    let mut distrib = FacetDistribution::new(&txn, &index);
+    distrib.facets(vec!["tags"]);
+    let result = distrib.execute().unwrap();
+    assert_eq!(result["tags"].len(), 2);
+}

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use slice_group_by::GroupBy;
 
 mod distinct;
+mod facet_distribution;
 mod filters;
 mod query_criteria;
 mod sort;


### PR DESCRIPTION
I cherry-picked the commits from these PRs
- https://github.com/meilisearch/milli/pull/518
- https://github.com/meilisearch/milli/pull/522
- https://github.com/meilisearch/milli/pull/520

`release-v0.26.4` has been started from the tag `v0.26.3` and not from main

The release tag `v0.26.4` will be done on the branch `release-v0.26.4` once this PR is merge