### PR TITLE
Simplify the error creation with thiserror

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -35,6 +35,7 @@ smallstr =  { version = "0.3.0", features = ["serde"] }
 smallvec = "1.8.0"
 smartstring = "1.0.1"
 tempfile = "3.3.0"
+thiserror = "1.0.31"
 time = { version = "0.3.7", features = ["serde-well-known", "formatting", "parsing", "macros"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 

--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -2,53 +2,26 @@ use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use crate::error::Error;
-use crate::{AscDesc, Member, UserError};
+use crate::{AscDesc, Member};
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum CriterionError {
+    #[error("`{name}` ranking rule is invalid. Valid ranking rules are Words, Typo, Sort, Proximity, Attribute, Exactness and custom ranking rules.")]
     InvalidName { name: String },
+    #[error("`{name}` is a reserved keyword and thus can't be used as a ranking rule")]
     ReservedName { name: String },
+    #[error(
+        "`{name}` is a reserved keyword and thus can't be used as a ranking rule. \
+`{name}` can only be used for sorting at search time"
+    )]
     ReservedNameForSort { name: String },
+    #[error(
+        "`{name}` is a reserved keyword and thus can't be used as a ranking rule. \
+`{name}` can only be used for filtering at search time"
+    )]
     ReservedNameForFilter { name: String },
-}
-
-impl fmt::Display for CriterionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidName { name } => write!(f, "`{}` ranking rule is invalid. Valid ranking rules are Words, Typo, Sort, Proximity, Attribute, Exactness and custom ranking rules.", name),
-            Self::ReservedName { name } => {
-                write!(
-                    f,
-                    "`{}` is a reserved keyword and thus can't be used as a ranking rule",
-                    name
-                )
-            }
-            Self::ReservedNameForSort { name } => {
-                write!(
-                    f,
-                    "`{}` is a reserved keyword and thus can't be used as a ranking rule. \
-`{}` can only be used for sorting at search time",
-                    name, name
-                )
-            }
-            Self::ReservedNameForFilter { name } => {
-                write!(
-                    f,
-                    "`{}` is a reserved keyword and thus can't be used as a ranking rule. \
-`{}` can only be used for filtering at search time",
-                    name, name
-                )
-            }
-        }
-    }
-}
-
-impl From<CriterionError> for Error {
-    fn from(error: CriterionError) -> Self {
-        Self::UserError(UserError::CriterionError(error))
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]


### PR DESCRIPTION
I introduced [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) to implements all the `Display` trait and most of the `impl From<xxx> for yyy` in way less lines.
And then I introduced a cute macro to implements the `impl<X, Y, Z> From<X> for Z where Y: From<X>, Z: From<X>` more easily.