### PR TITLE
Improves ranking rules error message

### DIFF
--- a/milli/src/criterion.rs
+++ b/milli/src/criterion.rs
@@ -8,7 +8,7 @@ use crate::{AscDesc, Member};
 
 #[derive(Error, Debug)]
 pub enum CriterionError {
-    #[error("`{name}` ranking rule is invalid. Valid ranking rules are Words, Typo, Sort, Proximity, Attribute, Exactness and custom ranking rules.")]
+    #[error("`{name}` ranking rule is invalid. Valid ranking rules are words, typo, sort, proximity, attribute, exactness and custom ranking rules.")]
     InvalidName { name: String },
     #[error("`{name}` is a reserved keyword and thus can't be used as a ranking rule")]
     ReservedName { name: String },


### PR DESCRIPTION
This PR improves the ranking rules error message to properly reflect the case sensitivity.
The issue was highlighted in [meilisearch/issues/2407](https://github.com/meilisearch/meilisearch/issues/2407).
Cheers!