### PR TITLE
speedup exact words

### DIFF
--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -1041,10 +1041,10 @@ impl Index {
     }
 
     /// List the words on which typo are not allowed
-    pub fn exact_words<'t>(&self, txn: &'t RoTxn) -> Result<fst::Set<Cow<'t, [u8]>>> {
+    pub fn exact_words<'t>(&self, txn: &'t RoTxn) -> Result<Option<fst::Set<Cow<'t, [u8]>>>> {
         match self.main.get::<_, Str, ByteSlice>(txn, main_key::EXACT_WORDS)? {
-            Some(bytes) => Ok(fst::Set::new(bytes)?.map_data(Cow::Borrowed)?),
-            None => Ok(fst::Set::default().map_data(Cow::Owned)?),
+            Some(bytes) => Ok(Some(fst::Set::new(bytes)?.map_data(Cow::Borrowed)?)),
+            None => Ok(None),
         }
     }
 

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -118,7 +118,7 @@ impl<'a> Search<'a> {
         let before = Instant::now();
         let (query_tree, primitive_query, matching_words) = match self.query.as_ref() {
             Some(query) => {
-                let mut builder = QueryTreeBuilder::new(self.rtxn, self.index);
+                let mut builder = QueryTreeBuilder::new(self.rtxn, self.index)?;
                 builder.optional_words(self.optional_words);
 
                 builder.authorize_typos(self.is_typo_authorized()?);

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -152,7 +152,7 @@ trait Context {
     }
     /// Returns the minimum word len for 1 and 2 typos.
     fn min_word_len_for_typo(&self) -> heed::Result<(u8, u8)>;
-    fn exact_words(&self) -> &Option<fst::Set<Cow<[u8]>>>;
+    fn exact_words(&self) -> Option<&fst::Set<Cow<[u8]>>>;
 }
 
 /// The query tree builder is the interface to build a query tree.
@@ -184,8 +184,8 @@ impl<'a> Context for QueryTreeBuilder<'a> {
         Ok((one, two))
     }
 
-    fn exact_words(&self) -> &Option<fst::Set<Cow<[u8]>>> {
-        &self.exact_words
+    fn exact_words(&self) -> Option<&fst::Set<Cow<[u8]>>> {
+        self.exact_words.as_ref()
     }
 }
 
@@ -286,7 +286,7 @@ pub struct TypoConfig<'a> {
     pub max_typos: u8,
     pub word_len_one_typo: u8,
     pub word_len_two_typo: u8,
-    pub exact_words: &'a Option<fst::Set<Cow<'a, [u8]>>>,
+    pub exact_words: Option<&'a fst::Set<Cow<'a, [u8]>>>,
 }
 
 /// Return the `QueryKind` of a word depending on `authorize_typos`
@@ -787,8 +787,8 @@ mod test {
             Ok((DEFAULT_MIN_WORD_LEN_ONE_TYPO, DEFAULT_MIN_WORD_LEN_TWO_TYPOS))
         }
 
-        fn exact_words(&self) -> &Option<fst::Set<Cow<[u8]>>> {
-            &self.exact_words
+        fn exact_words(&self) -> Option<&fst::Set<Cow<[u8]>>> {
+            self.exact_words.as_ref()
         }
     }
 
@@ -1415,12 +1415,12 @@ mod test {
 
     #[test]
     fn test_min_word_len_typo() {
-        let exact_words = Some(fst::Set::from_iter([b""]).unwrap().map_data(Cow::Owned).unwrap());
+        let exact_words = fst::Set::from_iter([b""]).unwrap().map_data(Cow::Owned).unwrap();
         let config = TypoConfig {
             max_typos: 2,
             word_len_one_typo: 5,
             word_len_two_typo: 7,
-            exact_words: &exact_words,
+            exact_words: Some(&exact_words),
         };
 
         assert_eq!(

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -193,14 +193,13 @@ impl<'a> QueryTreeBuilder<'a> {
     /// Create a `QueryTreeBuilder` from a heed ReadOnly transaction `rtxn`
     /// and an Index `index`.
     pub fn new(rtxn: &'a heed::RoTxn<'a>, index: &'a Index) -> Result<Self> {
-        let exact_words = index.exact_words(rtxn)?;
         Ok(Self {
             rtxn,
             index,
             optional_words: true,
             authorize_typos: true,
             words_limit: None,
-            exact_words,
+            exact_words: index.exact_words(rtxn)?,
         })
     }
 
@@ -292,7 +291,7 @@ pub struct TypoConfig<'a> {
 /// Return the `QueryKind` of a word depending on `authorize_typos`
 /// and the provided word length.
 fn typos<'a>(word: String, authorize_typos: bool, config: TypoConfig<'a>) -> QueryKind {
-    if authorize_typos && !config.exact_words.as_ref().map(|s| s.contains(&word)).unwrap_or(false) {
+    if authorize_typos && !config.exact_words.map_or(false, |s| s.contains(&word)) {
         let count = word.chars().count().min(u8::MAX as usize) as u8;
         if count < config.word_len_one_typo {
             QueryKind::exact(word)

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -1495,7 +1495,7 @@ mod tests {
         let words = btreeset! { S("Ab"), S("ac") };
         builder.set_exact_words(words);
         assert!(builder.execute(|_| ()).is_ok());
-        let exact_words = index.exact_words(&txn).unwrap();
+        let exact_words = index.exact_words(&txn).unwrap().unwrap();
         for word in exact_words.into_fst().stream().into_str_vec().unwrap() {
             assert!(word.0 == "ac" || word.0 == "ab");
         }


### PR DESCRIPTION
This PR make `exact_words` return an `Option` instead of an empty set, since set creation is costly, as noticed by @kerollmops.

I was not convinces that this was the cause for all of the performance drop we measured, and then realized that methods that initialized it were called recursively which caused initialization times to add up. While the first fix solves the issue when not using exact words, using exact word remained way more expensive that it should be. To address this issue, the exact words are cached into the `Context`, so they are only initialized once.
