### PR TITLE
Fix escaped quotes in filter

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2018"
 publish = false
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 publish = false

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filter-parser"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2021"
 description = "The parser for the Meilisearch filter syntax"
 publish = false

--- a/filter-parser/src/lib.rs
+++ b/filter-parser/src/lib.rs
@@ -40,7 +40,6 @@ mod error;
 mod value;
 
 use std::fmt::Debug;
-use std::ops::Deref;
 use std::str::FromStr;
 
 pub use condition::{parse_condition, parse_to, Condition};
@@ -70,14 +69,6 @@ pub struct Token<'a> {
     value: Option<String>,
 }
 
-impl<'a> Deref for Token<'a> {
-    type Target = &'a str;
-
-    fn deref(&self) -> &Self::Target {
-        &self.span
-    }
-}
-
 impl<'a> PartialEq for Token<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.span.fragment() == other.span.fragment()
@@ -87,6 +78,10 @@ impl<'a> PartialEq for Token<'a> {
 impl<'a> Token<'a> {
     pub fn new(span: Span<'a>, value: Option<String>) -> Self {
         Self { span, value }
+    }
+
+    pub fn lexeme(&self) -> &str {
+        &self.span
     }
 
     pub fn value(&self) -> &str {

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatten-serde-json"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.29.2"
+version = "0.29.3"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 description = "A small tool to do operations on the database"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.29.2"
+version = "0.29.3"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 publish = false

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.29.2"
+version = "0.29.3"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 publish = false

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-depth-checker"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2021"
 description = "A library that indicates if a JSON must be flattened"
 publish = false

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.29.2"
+version = "0.29.3"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Will fix https://github.com/meilisearch/meilisearch/issues/2380

The issue was that in the evaluation of the filter, I was using the deref implementation instead of calling the `value` method of my token.

To avoid the problem happening again, I removed the deref implementation; now, you need to either call the `lexeme` or the `value` methods but can't rely on a « default » implementation to get a string out of a token.