### PR TITLE
Ensure that Index methods are not bypassed by Meilisearch

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -229,7 +229,7 @@ impl Performer for DocumentAddition {
 
         println!("Adding {} documents to the index.", reader.len());
 
-        let mut txn = index.env.write_txn()?;
+        let mut txn = index.write_txn()?;
         let config = milli::update::IndexerConfig { log_every_n: Some(100), ..Default::default() };
         let update_method = if self.update_documents {
             IndexDocumentsMethod::UpdateDocuments
@@ -424,7 +424,7 @@ impl Search {
         offset: &Option<usize>,
         limit: &Option<usize>,
     ) -> Result<Vec<Map<String, Value>>> {
-        let txn = index.env.read_txn()?;
+        let txn = index.read_txn()?;
         let mut search = index.search(&txn);
 
         if let Some(ref query) = query {
@@ -475,7 +475,7 @@ struct SettingsUpdate {
 
 impl Performer for SettingsUpdate {
     fn perform(self, index: milli::Index) -> Result<()> {
-        let mut txn = index.env.write_txn()?;
+        let mut txn = index.write_txn()?;
 
         let config = IndexerConfig { log_every_n: Some(100), ..Default::default() };
 

--- a/infos/src/main.rs
+++ b/infos/src/main.rs
@@ -410,7 +410,7 @@ fn biggest_value_sizes(index: &Index, rtxn: &heed::RoTxn, limit: usize) -> anyho
         // Fetch the words FST
         let words_fst = index.words_fst(rtxn)?;
         let length = words_fst.as_fst().as_bytes().len();
-        heap.push(Reverse((length, format!("words-fst"), main_name)));
+        heap.push(Reverse((length, "words-fst".to_string(), main_name)));
         if heap.len() > limit {
             heap.pop();
         }
@@ -418,13 +418,13 @@ fn biggest_value_sizes(index: &Index, rtxn: &heed::RoTxn, limit: usize) -> anyho
         // Fetch the word prefix FST
         let words_prefixes_fst = index.words_prefixes_fst(rtxn)?;
         let length = words_prefixes_fst.as_fst().as_bytes().len();
-        heap.push(Reverse((length, format!("words-prefixes-fst"), main_name)));
+        heap.push(Reverse((length, "words-prefixes-fst".to_string(), main_name)));
         if heap.len() > limit {
             heap.pop();
         }
 
         let documents_ids = index.documents_ids(rtxn)?;
-        heap.push(Reverse((documents_ids.len() as usize, format!("documents-ids"), main_name)));
+        heap.push(Reverse((documents_ids.len() as usize, "documents-ids".to_string(), main_name)));
         if heap.len() > limit {
             heap.pop();
         }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -82,10 +82,10 @@ pub mod db_name {
 #[derive(Clone)]
 pub struct Index {
     /// The LMDB environment which this index is associated with.
-    pub env: heed::Env,
+    pub(crate) env: heed::Env,
 
     /// Contains many different types (e.g. the fields ids map).
-    pub main: PolyDatabase,
+    pub(crate) main: PolyDatabase,
 
     /// A word and all the documents ids containing the word.
     pub word_docids: Database<Str, RoaringBitmapCodec>,
@@ -125,7 +125,7 @@ pub struct Index {
     pub field_id_docid_facet_strings: Database<FieldDocIdFacetStringCodec, Str>,
 
     /// Maps the document id to the document as an obkv store.
-    pub documents: Database<OwnedType<BEU32>, ObkvCodec>,
+    pub(crate) documents: Database<OwnedType<BEU32>, ObkvCodec>,
 }
 
 impl Index {


### PR DESCRIPTION
#### tests: (skip in changelog)
- [x] placeholder search shouldn’t return soft deleted
- [x] search shouldn’t return soft deleted
- [x] filtered placeholder search shouldn’t return soft deleted
- [x] geo-filtered placeholder search shouldn’t return soft deleted
- [x] documents list/get shouldn’t return soft deleted
- [x] stats shouldn’t count soft deleted

#### other: (API breaking)
- [x] ensure that Index methods are not bypassed by Meilisearch


Poke @irevoire, we may merge this into your branch.