### PR TITLE
Fix not equal filter when field contains both number and strings

### DIFF
--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -306,12 +306,7 @@ impl<'a> Filter<'a> {
                 return Ok(string_docids | number_docids);
             }
             Condition::NotEqual(val) => {
-                let number = val.parse::<f64>().ok();
-                let all_numbers_ids = if number.is_some() {
-                    index.number_faceted_documents_ids(rtxn, field_id)?
-                } else {
-                    RoaringBitmap::new()
-                };
+                let all_numbers_ids = index.number_faceted_documents_ids(rtxn, field_id)?;
                 let all_strings_ids = index.string_faceted_documents_ids(rtxn, field_id)?;
                 let operator = Condition::Equal(val.clone());
                 let docids = Self::evaluate_operator(

--- a/milli/tests/search/filters.rs
+++ b/milli/tests/search/filters.rs
@@ -43,6 +43,9 @@ test_filter!(eq_mix_and_filter, vec![Right("tag=red"), Right("asc_desc_rank=1")]
 test_filter!(eq_string_or_filter, vec![Left(vec!["tag=red", "tag=green"])]);
 test_filter!(eq_mix_or_filter, vec![Left(vec!["tag=red", "asc_desc_rank=1"])]);
 test_filter!(eq_number_or_filter, vec![Left(vec!["asc_desc_rank=3", "asc_desc_rank=1"])]);
+test_filter!(neq_simple_string_filter, vec![Right("tag!=red")]);
+test_filter!(neq_simple_number_filter, vec![Right("asc_desc_rank!=1")]);
+test_filter!(neq_simple_string_in_number_column_filter, vec![Right("asc_desc_rank!=red")]);
 test_filter!(geo_radius, vec![Right("_geoRadius(50.630010347667806, 3.086251829166809, 100000)")]);
 test_filter!(
     not_geo_radius,

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -168,7 +168,15 @@ pub fn expected_order(
 
 fn execute_filter(filter: &str, document: &TestDocument) -> Option<String> {
     let mut id = None;
-    if let Some((field, filter)) = filter.split_once("=") {
+    if let Some((field, filter)) = filter.split_once("!=") {
+        if field == "tag" && document.tag != filter {
+            id = Some(document.id.clone())
+        } else if field == "asc_desc_rank"
+            && Ok(&document.asc_desc_rank) != filter.parse::<u32>().as_ref()
+        {
+            id = Some(document.id.clone())
+        }
+    } else if let Some((field, filter)) = filter.split_once("=") {
         if field == "tag" && document.tag == filter {
             id = Some(document.id.clone())
         } else if field == "asc_desc_rank"


### PR DESCRIPTION
Related to https://github.com/meilisearch/meilisearch/issues/2516
Looks like the issue should be moved to this repo, but I'm not sure what the right procedure for it.