### PR TITLE
Fix deserialisation of NDJson documents in benchmarks

### DIFF
--- a/benchmarks/benches/utils.rs
+++ b/benchmarks/benches/utils.rs
@@ -161,6 +161,7 @@ fn documents_from_jsonl(reader: impl Read) -> anyhow::Result<Vec<u8>> {
 
     while reader.read_line(&mut buf)? > 0 {
         documents.extend_from_json(&mut buf.as_bytes())?;
+        buf.clear();
     }
     documents.finish()?;
 


### PR DESCRIPTION
Previously, the first document in the NDJson file was read over and over again. So the `geo_point` benchmark was not working properly: it only indexed one document.