### PR TITLE
Add settings to force milli to exhaustively compute the total number of hits

### DIFF
--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -3,32 +3,35 @@ use roaring::RoaringBitmap;
 use super::{Criterion, CriterionParameters, CriterionResult};
 use crate::search::criteria::{resolve_query_tree, Context};
 use crate::search::query_tree::Operation;
+use crate::search::Distinct;
 use crate::Result;
 
-pub struct Initial<'t> {
+pub struct Initial<'t, D> {
     ctx: &'t dyn Context<'t>,
     answer: Option<CriterionResult>,
     exhaustive_number_hits: bool,
+    distinct: Option<D>,
 }
 
-impl<'t> Initial<'t> {
+impl<'t, D> Initial<'t, D> {
     pub fn new(
         ctx: &'t dyn Context<'t>,
         query_tree: Option<Operation>,
         filtered_candidates: Option<RoaringBitmap>,
         exhaustive_number_hits: bool,
-    ) -> Initial {
+        distinct: Option<D>,
+    ) -> Initial<D> {
         let answer = CriterionResult {
             query_tree,
             candidates: None,
             filtered_candidates,
             bucket_candidates: None,
         };
-        Initial { ctx, answer: Some(answer), exhaustive_number_hits }
+        Initial { ctx, answer: Some(answer), exhaustive_number_hits, distinct }
     }
 }
 
-impl Criterion for Initial<'_> {
+impl<D: Distinct> Criterion for Initial<'_, D> {
     #[logging_timer::time("Initial::{}")]
     fn next(&mut self, params: &mut CriterionParameters) -> Result<Option<CriterionResult>> {
         self.answer
@@ -41,8 +44,20 @@ impl Criterion for Initial<'_> {
                         &mut params.wdcache,
                     )?;
 
-                    answer.candidates = Some(candidates.clone());
-                    answer.bucket_candidates = Some(candidates);
+                    let bucket_candidates = match &mut self.distinct {
+                        // may be really time consuming
+                        Some(distinct) => {
+                            let mut bucket_candidates = RoaringBitmap::new();
+                            for c in distinct.distinct(candidates.clone(), RoaringBitmap::new()) {
+                                bucket_candidates.insert(c?);
+                            }
+                            bucket_candidates
+                        }
+                        None => candidates.clone(),
+                    };
+
+                    answer.candidates = Some(candidates);
+                    answer.bucket_candidates = Some(bucket_candidates);
                 }
                 Ok(answer)
             })

--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -40,7 +40,7 @@ impl<D: Distinct> Criterion for Initial<'_, D> {
             .take()
             .map(|mut answer| {
                 if self.exhaustive_number_hits && answer.query_tree.is_some() {
-                    // resolve the whole query tree to retrieve an exhastive list of documents matching the query.
+                    // resolve the whole query tree to retrieve an exhaustive list of documents matching the query.
                     let mut candidates = resolve_query_tree(
                         self.ctx,
                         answer.query_tree.as_ref().unwrap(),

--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -1,17 +1,22 @@
 use roaring::RoaringBitmap;
 
 use super::{Criterion, CriterionParameters, CriterionResult};
+use crate::search::criteria::{resolve_query_tree, Context};
 use crate::search::query_tree::Operation;
 use crate::Result;
 
-pub struct Initial {
+pub struct Initial<'t> {
+    ctx: &'t dyn Context<'t>,
     answer: Option<CriterionResult>,
+    exhaustive_number_hits: bool,
 }
 
-impl Initial {
+impl<'t> Initial<'t> {
     pub fn new(
+        ctx: &'t dyn Context<'t>,
         query_tree: Option<Operation>,
         filtered_candidates: Option<RoaringBitmap>,
+        exhaustive_number_hits: bool,
     ) -> Initial {
         let answer = CriterionResult {
             query_tree,
@@ -19,13 +24,28 @@ impl Initial {
             filtered_candidates,
             bucket_candidates: None,
         };
-        Initial { answer: Some(answer) }
+        Initial { ctx, answer: Some(answer), exhaustive_number_hits }
     }
 }
 
-impl Criterion for Initial {
+impl Criterion for Initial<'_> {
     #[logging_timer::time("Initial::{}")]
-    fn next(&mut self, _: &mut CriterionParameters) -> Result<Option<CriterionResult>> {
-        Ok(self.answer.take())
+    fn next(&mut self, params: &mut CriterionParameters) -> Result<Option<CriterionResult>> {
+        self.answer
+            .take()
+            .map(|mut answer| {
+                if self.exhaustive_number_hits && answer.query_tree.is_some() {
+                    let candidates = resolve_query_tree(
+                        self.ctx,
+                        answer.query_tree.as_ref().unwrap(),
+                        &mut params.wdcache,
+                    )?;
+
+                    answer.candidates = Some(candidates.clone());
+                    answer.bucket_candidates = Some(candidates);
+                }
+                Ok(answer)
+            })
+            .transpose()
     }
 }

--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -38,11 +38,15 @@ impl<D: Distinct> Criterion for Initial<'_, D> {
             .take()
             .map(|mut answer| {
                 if self.exhaustive_number_hits && answer.query_tree.is_some() {
-                    let candidates = resolve_query_tree(
+                    let mut candidates = resolve_query_tree(
                         self.ctx,
                         answer.query_tree.as_ref().unwrap(),
                         &mut params.wdcache,
                     )?;
+
+                    if let Some(ref filtered_candidates) = answer.filtered_candidates {
+                        candidates &= filtered_candidates;
+                    }
 
                     let bucket_candidates = match &mut self.distinct {
                         // may be really time consuming

--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -52,7 +52,7 @@ impl<D: Distinct> Criterion for Initial<'_, D> {
                         candidates &= filtered_candidates;
                     }
 
-                    // because the bucket_candidates should be an exhastive count of the matching documents,
+                    // because the bucket_candidates should be an exhaustive count of the matching documents,
                     // we precompute the distinct attributes.
                     let bucket_candidates = match &mut self.distinct {
                         Some(distinct) => {

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -13,7 +13,7 @@ use self::typo::Typo;
 use self::words::Words;
 use super::query_tree::{Operation, PrimitiveQueryPart, Query, QueryKind};
 use crate::search::criteria::geo::Geo;
-use crate::search::{word_derivations, WordDerivationsCache};
+use crate::search::{word_derivations, Distinct, WordDerivationsCache};
 use crate::{AscDesc as AscDescName, DocumentId, FieldId, Index, Member, Result};
 
 mod asc_desc;
@@ -226,21 +226,26 @@ impl<'t> CriteriaBuilder<'t> {
         Ok(Self { rtxn, index, words_fst, words_prefixes_fst })
     }
 
-    pub fn build(
+    pub fn build<D: 't + Distinct>(
         &'t self,
         query_tree: Option<Operation>,
         primitive_query: Option<Vec<PrimitiveQueryPart>>,
         filtered_candidates: Option<RoaringBitmap>,
         sort_criteria: Option<Vec<AscDescName>>,
         exhaustive_number_hits: bool,
+        distinct: Option<D>,
     ) -> Result<Final<'t>> {
         use crate::criterion::Criterion as Name;
 
         let primitive_query = primitive_query.unwrap_or_default();
 
-        let mut criterion =
-            Box::new(Initial::new(self, query_tree, filtered_candidates, exhaustive_number_hits))
-                as Box<dyn Criterion>;
+        let mut criterion = Box::new(Initial::new(
+            self,
+            query_tree,
+            filtered_candidates,
+            exhaustive_number_hits,
+            distinct,
+        )) as Box<dyn Criterion>;
         for name in self.index.criteria(&self.rtxn)? {
             criterion = match name {
                 Name::Words => Box::new(Words::new(self, criterion)),

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -232,13 +232,15 @@ impl<'t> CriteriaBuilder<'t> {
         primitive_query: Option<Vec<PrimitiveQueryPart>>,
         filtered_candidates: Option<RoaringBitmap>,
         sort_criteria: Option<Vec<AscDescName>>,
+        exhaustive_number_hits: bool,
     ) -> Result<Final<'t>> {
         use crate::criterion::Criterion as Name;
 
         let primitive_query = primitive_query.unwrap_or_default();
 
         let mut criterion =
-            Box::new(Initial::new(query_tree, filtered_candidates)) as Box<dyn Criterion>;
+            Box::new(Initial::new(self, query_tree, filtered_candidates, exhaustive_number_hits))
+                as Box<dyn Criterion>;
         for name in self.index.criteria(&self.rtxn)? {
             criterion = match name {
                 Name::Words => Box::new(Words::new(self, criterion)),

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -368,7 +368,7 @@ mod test {
             excluded_candidates: &RoaringBitmap::new(),
         };
 
-        let parent = Initial::new(query_tree, facet_candidates);
+        let parent = Initial::new(&context, query_tree, facet_candidates, false);
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);
@@ -405,7 +405,7 @@ mod test {
             wdcache: &mut WordDerivationsCache::new(),
             excluded_candidates: &RoaringBitmap::new(),
         };
-        let parent = Initial::new(Some(query_tree), facet_candidates);
+        let parent = Initial::new(&context, Some(query_tree), facet_candidates, false);
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);
@@ -439,7 +439,7 @@ mod test {
             wdcache: &mut WordDerivationsCache::new(),
             excluded_candidates: &RoaringBitmap::new(),
         };
-        let parent = Initial::new(query_tree, Some(facet_candidates.clone()));
+        let parent = Initial::new(&context, query_tree, Some(facet_candidates.clone()), false);
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);
@@ -476,7 +476,8 @@ mod test {
             wdcache: &mut WordDerivationsCache::new(),
             excluded_candidates: &RoaringBitmap::new(),
         };
-        let parent = Initial::new(Some(query_tree), Some(facet_candidates.clone()));
+        let parent =
+            Initial::new(&context, Some(query_tree), Some(facet_candidates.clone()), false);
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -348,6 +348,7 @@ mod test {
     use super::super::initial::Initial;
     use super::super::test::TestContext;
     use super::*;
+    use crate::search::NoopDistinct;
 
     fn display_criteria(mut criteria: Typo, mut parameters: CriterionParameters) -> String {
         let mut result = String::new();
@@ -368,7 +369,8 @@ mod test {
             excluded_candidates: &RoaringBitmap::new(),
         };
 
-        let parent = Initial::new(&context, query_tree, facet_candidates, false);
+        let parent =
+            Initial::<NoopDistinct>::new(&context, query_tree, facet_candidates, false, None);
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);
@@ -405,7 +407,8 @@ mod test {
             wdcache: &mut WordDerivationsCache::new(),
             excluded_candidates: &RoaringBitmap::new(),
         };
-        let parent = Initial::new(&context, Some(query_tree), facet_candidates, false);
+        let parent =
+            Initial::<NoopDistinct>::new(&context, Some(query_tree), facet_candidates, false, None);
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);
@@ -439,7 +442,13 @@ mod test {
             wdcache: &mut WordDerivationsCache::new(),
             excluded_candidates: &RoaringBitmap::new(),
         };
-        let parent = Initial::new(&context, query_tree, Some(facet_candidates.clone()), false);
+        let parent = Initial::<NoopDistinct>::new(
+            &context,
+            query_tree,
+            Some(facet_candidates.clone()),
+            false,
+            None,
+        );
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);
@@ -476,8 +485,13 @@ mod test {
             wdcache: &mut WordDerivationsCache::new(),
             excluded_candidates: &RoaringBitmap::new(),
         };
-        let parent =
-            Initial::new(&context, Some(query_tree), Some(facet_candidates.clone()), false);
+        let parent = Initial::<NoopDistinct>::new(
+            &context,
+            Some(query_tree),
+            Some(facet_candidates.clone()),
+            false,
+            None,
+        );
         let criteria = Typo::new(&context, Box::new(parent));
 
         let result = display_criteria(criteria, criterion_parameters);

--- a/milli/src/search/distinct/facet_distinct.rs
+++ b/milli/src/search/distinct/facet_distinct.rs
@@ -21,6 +21,7 @@ const DOCID_SIZE: usize = size_of::<DocumentId>();
 /// care to keep the document we are currently on, and remove it from the excluded list. The next
 /// iterations will never contain any occurence of a document with the same distinct value as a
 /// document from previous iterations.
+#[derive(Clone)]
 pub struct FacetDistinct<'a> {
     distinct: FieldId,
     index: &'a Index,

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -109,6 +109,8 @@ impl<'a> Search<'a> {
         self
     }
 
+    /// Force the search to exhastivelly compute the number of candidates,
+    /// this will increase the search time but allows finite pagination.
     pub fn exhaustive_number_hits(&mut self, exhaustive_number_hits: bool) -> &mut Search<'a> {
         self.exhaustive_number_hits = exhaustive_number_hits;
         self

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -47,6 +47,7 @@ pub struct Search<'a> {
     terms_matching_strategy: TermsMatchingStrategy,
     authorize_typos: bool,
     words_limit: usize,
+    exhaustive_number_hits: bool,
     rtxn: &'a heed::RoTxn<'a>,
     index: &'a Index,
 }
@@ -61,6 +62,7 @@ impl<'a> Search<'a> {
             sort_criteria: None,
             terms_matching_strategy: TermsMatchingStrategy::default(),
             authorize_typos: true,
+            exhaustive_number_hits: false,
             words_limit: 10,
             rtxn,
             index,
@@ -104,6 +106,11 @@ impl<'a> Search<'a> {
 
     pub fn filter(&mut self, condition: Filter<'a>) -> &mut Search<'a> {
         self.filter = Some(condition);
+        self
+    }
+
+    pub fn exhaustive_number_hits(&mut self, exhaustive_number_hits: bool) -> &mut Search<'a> {
+        self.exhaustive_number_hits = exhaustive_number_hits;
         self
     }
 
@@ -189,6 +196,7 @@ impl<'a> Search<'a> {
             primitive_query,
             filtered_candidates,
             self.sort_criteria.clone(),
+            self.exhaustive_number_hits,
         )?;
 
         match self.index.distinct_field(self.rtxn)? {
@@ -262,6 +270,7 @@ impl fmt::Debug for Search<'_> {
             terms_matching_strategy,
             authorize_typos,
             words_limit,
+            exhaustive_number_hits,
             rtxn: _,
             index: _,
         } = self;
@@ -273,6 +282,7 @@ impl fmt::Debug for Search<'_> {
             .field("sort_criteria", sort_criteria)
             .field("terms_matching_strategy", terms_matching_strategy)
             .field("authorize_typos", authorize_typos)
+            .field("exhaustive_number_hits", exhaustive_number_hits)
             .field("words_limit", words_limit)
             .finish()
     }

--- a/milli/tests/search/query_criteria.rs
+++ b/milli/tests/search/query_criteria.rs
@@ -51,7 +51,7 @@ macro_rules! test_criterion {
     };
 }
 
-test_criterion!(none_allow_typo, ALLOW_OPTIONAL_WORDS, ALLOW_TYPOS, vec![], vec![]);
+test_criterion!(none_allow_typo, DISALLOW_OPTIONAL_WORDS, ALLOW_TYPOS, vec![], vec![]);
 test_criterion!(none_disallow_typo, DISALLOW_OPTIONAL_WORDS, DISALLOW_TYPOS, vec![], vec![]);
 test_criterion!(words_allow_typo, ALLOW_OPTIONAL_WORDS, ALLOW_TYPOS, vec![Words], vec![]);
 test_criterion!(


### PR DESCRIPTION
Add a new setting `exhaustive_number_hits` to `Search` forcing the `Initial` criterion to exhaustively compute the bucket_candidates allowing the end users to implement finite pagination.
 
related to https://github.com/meilisearch/meilisearch/pull/2601