### PR TITLE
Fix(smart-crop): Ensure that matches are all highlighted

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2018"
 publish = false
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 publish = false

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filter-parser"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 description = "The parser for the Meilisearch filter syntax"
 publish = false

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatten-serde-json"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 description = "A small tool to do operations on the database"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 publish = false

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 publish = false

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-depth-checker"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 description = "A library that indicates if a JSON must be flattened"
 publish = false

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
In the case of only 1 query word was matching in an attribute,
and this same word was matching several times in the crop window of the same attribute,
then only the first match was highlighted.
Now we ensure that the computed "best matches interval" contains all the words that match in the same crop window.

related to https://github.com/meilisearch/meilisearch/issues/2627

