### PR TITLE
Update version for next release (v0.32.0)

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2018"
 publish = false
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2018"
 description = "A CLI to interact with a milli index"
 publish = false

--- a/filter-parser/Cargo.toml
+++ b/filter-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filter-parser"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 description = "The parser for the Meilisearch filter syntax"
 publish = false

--- a/flatten-serde-json/Cargo.toml
+++ b/flatten-serde-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatten-serde-json"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 description = "Flatten serde-json objects like elastic search"
 readme = "README.md"

--- a/helpers/Cargo.toml
+++ b/helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helpers"
-version = "0.31.1"
+version = "0.32.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 description = "A small tool to do operations on the database"

--- a/http-ui/Cargo.toml
+++ b/http-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-ui"
 description = "The HTTP user interface of the milli search engine"
-version = "0.31.1"
+version = "0.32.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 publish = false

--- a/infos/Cargo.toml
+++ b/infos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infos"
-version = "0.31.1"
+version = "0.32.0"
 authors = ["Clément Renault <clement@meilisearch.com>"]
 edition = "2018"
 publish = false

--- a/json-depth-checker/Cargo.toml
+++ b/json-depth-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-depth-checker"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 description = "A library that indicates if a JSON must be flattened"
 publish = false

--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milli"
-version = "0.31.1"
+version = "0.32.0"
 authors = ["Kerollmops <clement@meilisearch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
In order to release on `main` (for v0.29.0, not v0.28.1)

<img width="1014" alt="Capture d’écran 2022-07-21 à 13 20 35" src="https://user-images.githubusercontent.com/20380692/180178725-381fbdf1-c0fb-4fa9-9954-452aec5a1574.png">
