### PR TITLE
Matching query terms policy

### DIFF
--- a/benchmarks/benches/utils.rs
+++ b/benchmarks/benches/utils.rs
@@ -119,7 +119,7 @@ pub fn run_benches(c: &mut criterion::Criterion, confs: &[Conf]) {
                 b.iter(|| {
                     let rtxn = index.read_txn().unwrap();
                     let mut search = index.search(&rtxn);
-                    search.query(query).optional_words(TermsMatchingStrategy::default());
+                    search.query(query).terms_matching_strategy(TermsMatchingStrategy::default());
                     if let Some(filter) = conf.filter {
                         let filter = Filter::from_str(filter).unwrap().unwrap();
                         search.filter(filter);

--- a/benchmarks/benches/utils.rs
+++ b/benchmarks/benches/utils.rs
@@ -11,7 +11,7 @@ use milli::heed::EnvOpenOptions;
 use milli::update::{
     IndexDocuments, IndexDocumentsConfig, IndexDocumentsMethod, IndexerConfig, Settings,
 };
-use milli::{Filter, Index, Object};
+use milli::{Filter, Index, Object, TermsMatchingStrategy};
 use serde_json::Value;
 
 pub struct Conf<'a> {
@@ -119,7 +119,7 @@ pub fn run_benches(c: &mut criterion::Criterion, confs: &[Conf]) {
                 b.iter(|| {
                     let rtxn = index.read_txn().unwrap();
                     let mut search = index.search(&rtxn);
-                    search.query(query).optional_words(conf.optional_words);
+                    search.query(query).optional_words(TermsMatchingStrategy::default());
                     if let Some(filter) = conf.filter {
                         let filter = Filter::from_str(filter).unwrap().unwrap();
                         search.filter(filter);

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::heed_codec::{
 pub use self::index::Index;
 pub use self::search::{
     FacetDistribution, Filter, FormatOptions, MatchBounds, MatcherBuilder, MatchingWord,
-    MatchingWords, Search, SearchResult, DEFAULT_VALUES_PER_FACET,
+    MatchingWords, Search, SearchResult, TermsMatchingStrategy, DEFAULT_VALUES_PER_FACET,
 };
 
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -44,7 +44,7 @@ pub struct Search<'a> {
     offset: usize,
     limit: usize,
     sort_criteria: Option<Vec<AscDesc>>,
-    optional_words: bool,
+    optional_words: TermsMatchingStrategy,
     authorize_typos: bool,
     words_limit: usize,
     rtxn: &'a heed::RoTxn<'a>,
@@ -59,7 +59,7 @@ impl<'a> Search<'a> {
             offset: 0,
             limit: 20,
             sort_criteria: None,
-            optional_words: true,
+            optional_words: TermsMatchingStrategy::default(),
             authorize_typos: true,
             words_limit: 10,
             rtxn,
@@ -87,7 +87,7 @@ impl<'a> Search<'a> {
         self
     }
 
-    pub fn optional_words(&mut self, value: bool) -> &mut Search<'a> {
+    pub fn optional_words(&mut self, value: TermsMatchingStrategy) -> &mut Search<'a> {
         self.optional_words = value;
         self
     }
@@ -284,6 +284,28 @@ pub struct SearchResult {
     pub candidates: RoaringBitmap,
     // TODO those documents ids should be associated with their criteria scores.
     pub documents_ids: Vec<DocumentId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TermsMatchingStrategy {
+    // remove last word first
+    Last,
+    // remove first word first
+    First,
+    // remove more frequent word first
+    Frequency,
+    // remove smallest word first
+    Size,
+    // only one of the word is mandatory
+    Any,
+    // all words are mandatory
+    All,
+}
+
+impl Default for TermsMatchingStrategy {
+    fn default() -> Self {
+        Self::Last
+    }
 }
 
 pub type WordDerivationsCache = HashMap<(String, bool, u8), Vec<(String, u8)>>;

--- a/milli/src/search/mod.rs
+++ b/milli/src/search/mod.rs
@@ -44,7 +44,7 @@ pub struct Search<'a> {
     offset: usize,
     limit: usize,
     sort_criteria: Option<Vec<AscDesc>>,
-    optional_words: TermsMatchingStrategy,
+    terms_matching_strategy: TermsMatchingStrategy,
     authorize_typos: bool,
     words_limit: usize,
     rtxn: &'a heed::RoTxn<'a>,
@@ -59,7 +59,7 @@ impl<'a> Search<'a> {
             offset: 0,
             limit: 20,
             sort_criteria: None,
-            optional_words: TermsMatchingStrategy::default(),
+            terms_matching_strategy: TermsMatchingStrategy::default(),
             authorize_typos: true,
             words_limit: 10,
             rtxn,
@@ -87,8 +87,8 @@ impl<'a> Search<'a> {
         self
     }
 
-    pub fn optional_words(&mut self, value: TermsMatchingStrategy) -> &mut Search<'a> {
-        self.optional_words = value;
+    pub fn terms_matching_strategy(&mut self, value: TermsMatchingStrategy) -> &mut Search<'a> {
+        self.terms_matching_strategy = value;
         self
     }
 
@@ -119,7 +119,7 @@ impl<'a> Search<'a> {
         let (query_tree, primitive_query, matching_words) = match self.query.as_ref() {
             Some(query) => {
                 let mut builder = QueryTreeBuilder::new(self.rtxn, self.index)?;
-                builder.optional_words(self.optional_words);
+                builder.terms_matching_strategy(self.terms_matching_strategy);
 
                 builder.authorize_typos(self.is_typo_authorized()?);
 
@@ -259,7 +259,7 @@ impl fmt::Debug for Search<'_> {
             offset,
             limit,
             sort_criteria,
-            optional_words,
+            terms_matching_strategy,
             authorize_typos,
             words_limit,
             rtxn: _,
@@ -271,7 +271,7 @@ impl fmt::Debug for Search<'_> {
             .field("offset", offset)
             .field("limit", limit)
             .field("sort_criteria", sort_criteria)
-            .field("optional_words", optional_words)
+            .field("terms_matching_strategy", terms_matching_strategy)
             .field("authorize_typos", authorize_typos)
             .field("words_limit", words_limit)
             .finish()

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -454,7 +454,7 @@ fn create_query_tree(
 
     let mut operation_children = Vec::new();
     let mut query = query.to_vec();
-    for _ in 0..=remove_count {
+    for _ in 0..remove_count {
         let pos = match optional_words {
             TermsMatchingStrategy::All => return ngrams(ctx, authorize_typos, &query, false),
             TermsMatchingStrategy::Any => {
@@ -511,7 +511,7 @@ fn create_query_tree(
         };
     }
 
-    Ok(Operation::Or(true, operation_children))
+    Ok(Operation::or(true, operation_children))
 }
 
 /// Main function that matchings words used for crop and highlight.

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -454,7 +454,7 @@ fn create_query_tree(
 
     let mut operation_children = Vec::new();
     let mut query = query.to_vec();
-    for _ in 0..remove_count {
+    for _ in 0..=remove_count {
         let pos = match optional_words {
             TermsMatchingStrategy::All => return ngrams(ctx, authorize_typos, &query, false),
             TermsMatchingStrategy::Any => {

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -613,6 +613,7 @@ mod tests {
     use super::*;
     use crate::documents::documents_batch_reader_from_objects;
     use crate::index::tests::TempIndex;
+    use crate::search::TermsMatchingStrategy;
     use crate::update::DeleteDocuments;
     use crate::BEU16;
 
@@ -1207,7 +1208,7 @@ mod tests {
         let mut search = crate::Search::new(&rtxn, &index);
         search.query("document");
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
         // all documents should be returned
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids.len(), 4);
@@ -1313,7 +1314,7 @@ mod tests {
         let mut search = crate::Search::new(&rtxn, &index);
         search.query("document");
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
         // all documents should be returned
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids.len(), 4);
@@ -1512,7 +1513,7 @@ mod tests {
         let mut search = crate::Search::new(&rtxn, &index);
         search.query("化妆包");
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         // only 1 document should be returned
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -1208,7 +1208,7 @@ mod tests {
         let mut search = crate::Search::new(&rtxn, &index);
         search.query("document");
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
         // all documents should be returned
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids.len(), 4);
@@ -1314,7 +1314,7 @@ mod tests {
         let mut search = crate::Search::new(&rtxn, &index);
         search.query("document");
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
         // all documents should be returned
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();
         assert_eq!(documents_ids.len(), 4);
@@ -1513,7 +1513,7 @@ mod tests {
         let mut search = crate::Search::new(&rtxn, &index);
         search.query("化妆包");
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         // only 1 document should be returned
         let crate::SearchResult { documents_ids, .. } = search.execute().unwrap();

--- a/milli/tests/search/distinct.rs
+++ b/milli/tests/search/distinct.rs
@@ -28,7 +28,7 @@ macro_rules! test_distinct {
             search.query(search::TEST_QUERY);
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
             search.authorize_typos(true);
-            search.optional_words(TermsMatchingStrategy::default());
+            search.terms_matching_strategy(TermsMatchingStrategy::default());
 
             let SearchResult { documents_ids, candidates, .. } = search.execute().unwrap();
 

--- a/milli/tests/search/filters.rs
+++ b/milli/tests/search/filters.rs
@@ -19,7 +19,7 @@ macro_rules! test_filter {
             search.query(search::TEST_QUERY);
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
             search.authorize_typos(true);
-            search.optional_words(TermsMatchingStrategy::default());
+            search.terms_matching_strategy(TermsMatchingStrategy::default());
             search.filter(filter_conditions);
 
             let SearchResult { documents_ids, .. } = search.execute().unwrap();

--- a/milli/tests/search/filters.rs
+++ b/milli/tests/search/filters.rs
@@ -1,5 +1,5 @@
 use either::{Either, Left, Right};
-use milli::{Criterion, Filter, Search, SearchResult};
+use milli::{Criterion, Filter, Search, SearchResult, TermsMatchingStrategy};
 use Criterion::*;
 
 use crate::search::{self, EXTERNAL_DOCUMENTS_IDS};
@@ -19,16 +19,17 @@ macro_rules! test_filter {
             search.query(search::TEST_QUERY);
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
             search.authorize_typos(true);
-            search.optional_words(true);
+            search.optional_words(TermsMatchingStrategy::default());
             search.filter(filter_conditions);
 
             let SearchResult { documents_ids, .. } = search.execute().unwrap();
 
             let filtered_ids = search::expected_filtered_ids($filter);
-            let expected_external_ids: Vec<_> = search::expected_order(&criteria, true, true, &[])
-                .into_iter()
-                .filter_map(|d| if filtered_ids.contains(&d.id) { Some(d.id) } else { None })
-                .collect();
+            let expected_external_ids: Vec<_> =
+                search::expected_order(&criteria, true, TermsMatchingStrategy::default(), &[])
+                    .into_iter()
+                    .filter_map(|d| if filtered_ids.contains(&d.id) { Some(d.id) } else { None })
+                    .collect();
 
             let documents_ids = search::internal_to_external_ids(&index, &documents_ids);
             assert_eq!(documents_ids, expected_external_ids);

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -8,7 +8,7 @@ use heed::EnvOpenOptions;
 use maplit::{hashmap, hashset};
 use milli::documents::{DocumentsBatchBuilder, DocumentsBatchReader};
 use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig, Settings};
-use milli::{AscDesc, Criterion, DocumentId, Index, Member, Object};
+use milli::{AscDesc, Criterion, DocumentId, Index, Member, Object, TermsMatchingStrategy};
 use serde::{Deserialize, Deserializer};
 use slice_group_by::GroupBy;
 
@@ -96,7 +96,7 @@ pub fn internal_to_external_ids(index: &Index, internal_ids: &[DocumentId]) -> V
 pub fn expected_order(
     criteria: &[Criterion],
     authorize_typo: bool,
-    optional_words: bool,
+    optional_words: TermsMatchingStrategy,
     sort_by: &[AscDesc],
 ) -> Vec<TestDocument> {
     let dataset =
@@ -155,9 +155,9 @@ pub fn expected_order(
         groups = std::mem::take(&mut new_groups);
     }
 
-    if authorize_typo && optional_words {
+    if authorize_typo && optional_words == TermsMatchingStrategy::default() {
         groups.into_iter().flatten().collect()
-    } else if optional_words {
+    } else if optional_words == TermsMatchingStrategy::default() {
         groups.into_iter().flatten().filter(|d| d.typo_rank == 0).collect()
     } else if authorize_typo {
         groups.into_iter().flatten().filter(|d| d.word_rank == 0).collect()

--- a/milli/tests/search/query_criteria.rs
+++ b/milli/tests/search/query_criteria.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use maplit::hashset;
 use milli::documents::{DocumentsBatchBuilder, DocumentsBatchReader};
 use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig, Settings};
-use milli::{AscDesc, Criterion, Index, Member, Search, SearchResult};
+use milli::{AscDesc, Criterion, Index, Member, Search, SearchResult, TermsMatchingStrategy};
 use rand::Rng;
 use Criterion::*;
 
@@ -15,8 +15,8 @@ use crate::search::{self, EXTERNAL_DOCUMENTS_IDS};
 
 const ALLOW_TYPOS: bool = true;
 const DISALLOW_TYPOS: bool = false;
-const ALLOW_OPTIONAL_WORDS: bool = true;
-const DISALLOW_OPTIONAL_WORDS: bool = false;
+const ALLOW_OPTIONAL_WORDS: TermsMatchingStrategy = TermsMatchingStrategy::Last;
+const DISALLOW_OPTIONAL_WORDS: TermsMatchingStrategy = TermsMatchingStrategy::All;
 const ASC_DESC_CANDIDATES_THRESHOLD: usize = 1000;
 
 macro_rules! test_criterion {
@@ -359,7 +359,7 @@ fn criteria_mixup() {
         let SearchResult { documents_ids, .. } = search.execute().unwrap();
 
         let expected_external_ids: Vec<_> =
-            search::expected_order(&criteria, ALLOW_OPTIONAL_WORDS, ALLOW_TYPOS, &[])
+            search::expected_order(&criteria, ALLOW_TYPOS, ALLOW_OPTIONAL_WORDS, &[])
                 .into_iter()
                 .map(|d| d.id)
                 .collect();

--- a/milli/tests/search/query_criteria.rs
+++ b/milli/tests/search/query_criteria.rs
@@ -31,7 +31,7 @@ macro_rules! test_criterion {
             search.query(search::TEST_QUERY);
             search.limit(EXTERNAL_DOCUMENTS_IDS.len());
             search.authorize_typos($authorize_typos);
-            search.optional_words($optional_word);
+            search.terms_matching_strategy($optional_word);
             search.sort_criteria($sort_criteria);
 
             let SearchResult { documents_ids, .. } = search.execute().unwrap();
@@ -353,7 +353,7 @@ fn criteria_mixup() {
         let mut search = Search::new(&mut rtxn, &index);
         search.query(search::TEST_QUERY);
         search.limit(EXTERNAL_DOCUMENTS_IDS.len());
-        search.optional_words(ALLOW_OPTIONAL_WORDS);
+        search.terms_matching_strategy(ALLOW_OPTIONAL_WORDS);
         search.authorize_typos(ALLOW_TYPOS);
 
         let SearchResult { documents_ids, .. } = search.execute().unwrap();

--- a/milli/tests/search/sort.rs
+++ b/milli/tests/search/sort.rs
@@ -1,6 +1,6 @@
 use big_s::S;
 use milli::Criterion::{Attribute, Exactness, Proximity, Typo, Words};
-use milli::{AscDesc, Error, Member, Search, UserError};
+use milli::{AscDesc, Error, Member, Search, TermsMatchingStrategy, UserError};
 
 use crate::search::{self, EXTERNAL_DOCUMENTS_IDS};
 
@@ -15,7 +15,7 @@ fn sort_ranking_rule_missing() {
     search.query(search::TEST_QUERY);
     search.limit(EXTERNAL_DOCUMENTS_IDS.len());
     search.authorize_typos(true);
-    search.optional_words(true);
+    search.optional_words(TermsMatchingStrategy::default());
     search.sort_criteria(vec![AscDesc::Asc(Member::Field(S("tag")))]);
 
     let result = search.execute();

--- a/milli/tests/search/sort.rs
+++ b/milli/tests/search/sort.rs
@@ -15,7 +15,7 @@ fn sort_ranking_rule_missing() {
     search.query(search::TEST_QUERY);
     search.limit(EXTERNAL_DOCUMENTS_IDS.len());
     search.authorize_typos(true);
-    search.optional_words(TermsMatchingStrategy::default());
+    search.terms_matching_strategy(TermsMatchingStrategy::default());
     search.sort_criteria(vec![AscDesc::Asc(Member::Field(S("tag")))]);
 
     let result = search.execute();

--- a/milli/tests/search/typo_tolerance.rs
+++ b/milli/tests/search/typo_tolerance.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use heed::EnvOpenOptions;
 use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig, Settings};
-use milli::{Criterion, Index, Search};
+use milli::{Criterion, Index, Search, TermsMatchingStrategy};
 use serde_json::json;
 use tempfile::tempdir;
 use Criterion::*;
@@ -20,7 +20,7 @@ fn test_typo_tolerance_one_typo() {
         search.query("zeal");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 1);
@@ -29,7 +29,7 @@ fn test_typo_tolerance_one_typo() {
         search.query("zean");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 0);
@@ -47,7 +47,7 @@ fn test_typo_tolerance_one_typo() {
     search.query("zean");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(true);
+    search.optional_words(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
@@ -66,7 +66,7 @@ fn test_typo_tolerance_two_typo() {
         search.query("zealand");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 1);
@@ -75,7 +75,7 @@ fn test_typo_tolerance_two_typo() {
         search.query("zealemd");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 0);
@@ -93,7 +93,7 @@ fn test_typo_tolerance_two_typo() {
     search.query("zealemd");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(true);
+    search.optional_words(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
@@ -142,7 +142,7 @@ fn test_typo_disabled_on_word() {
         search.query("zealand");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 2);
@@ -162,7 +162,7 @@ fn test_typo_disabled_on_word() {
     search.query("zealand");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(true);
+    search.optional_words(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
@@ -182,7 +182,7 @@ fn test_disable_typo_on_attribute() {
         search.query("antebelum");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(true);
+        search.optional_words(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 1);
@@ -200,7 +200,7 @@ fn test_disable_typo_on_attribute() {
     search.query("antebelum");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(true);
+    search.optional_words(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 0);

--- a/milli/tests/search/typo_tolerance.rs
+++ b/milli/tests/search/typo_tolerance.rs
@@ -20,7 +20,7 @@ fn test_typo_tolerance_one_typo() {
         search.query("zeal");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 1);
@@ -29,7 +29,7 @@ fn test_typo_tolerance_one_typo() {
         search.query("zean");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 0);
@@ -47,7 +47,7 @@ fn test_typo_tolerance_one_typo() {
     search.query("zean");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(TermsMatchingStrategy::default());
+    search.terms_matching_strategy(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
@@ -66,7 +66,7 @@ fn test_typo_tolerance_two_typo() {
         search.query("zealand");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 1);
@@ -75,7 +75,7 @@ fn test_typo_tolerance_two_typo() {
         search.query("zealemd");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 0);
@@ -93,7 +93,7 @@ fn test_typo_tolerance_two_typo() {
     search.query("zealemd");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(TermsMatchingStrategy::default());
+    search.terms_matching_strategy(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
@@ -142,7 +142,7 @@ fn test_typo_disabled_on_word() {
         search.query("zealand");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 2);
@@ -162,7 +162,7 @@ fn test_typo_disabled_on_word() {
     search.query("zealand");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(TermsMatchingStrategy::default());
+    search.terms_matching_strategy(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 1);
@@ -182,7 +182,7 @@ fn test_disable_typo_on_attribute() {
         search.query("antebelum");
         search.limit(10);
         search.authorize_typos(true);
-        search.optional_words(TermsMatchingStrategy::default());
+        search.terms_matching_strategy(TermsMatchingStrategy::default());
 
         let result = search.execute().unwrap();
         assert_eq!(result.documents_ids.len(), 1);
@@ -200,7 +200,7 @@ fn test_disable_typo_on_attribute() {
     search.query("antebelum");
     search.limit(10);
     search.authorize_typos(true);
-    search.optional_words(TermsMatchingStrategy::default());
+    search.terms_matching_strategy(TermsMatchingStrategy::default());
 
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 0);


### PR DESCRIPTION
## Summary

Implement several optional words strategy.

## Content

Replace `optional_words` boolean with an enum containing several term matching strategies:
```rust
pub enum TermsMatchingStrategy {
    // remove last word first
    Last,
    // remove first word first
    First,
    // remove more frequent word first
    Frequency,
    // remove smallest word first
    Size,
    // only one of the word is mandatory
    Any,
    // all words are mandatory
    All,
}
```

All strategies implemented during the prototype are kept, but only `Last` and `All` will be published by Meilisearch in the `v0.29.0` release.

## Related

spec: https://github.com/meilisearch/specifications/pull/173
prototype discussion: https://github.com/meilisearch/meilisearch/discussions/2639#discussioncomment-3447699
