### PR TITLE
fix: Remove whitespace trimming during document id validation

### DIFF
--- a/milli/src/update/index_documents/enrich.rs
+++ b/milli/src/update/index_documents/enrich.rs
@@ -294,9 +294,7 @@ pub fn fetch_matching_values_in_object(
     }
 }
 
-/// Returns a trimmed version of the document id or `None` if it is invalid.
 pub fn validate_document_id(document_id: &str) -> Option<&str> {
-    let document_id = document_id.trim();
     if !document_id.is_empty()
         && document_id.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_'))
     {

--- a/milli/src/update/index_documents/mod.rs
+++ b/milli/src/update/index_documents/mod.rs
@@ -2086,4 +2086,51 @@ mod tests {
         let (_builder, user_error) = builder.add_documents(doc4).unwrap();
         assert!(user_error.is_err());
     }
+
+    #[test]
+    fn primary_key_must_not_contain_whitespace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut options = EnvOpenOptions::new();
+        options.map_size(4096 * 100);
+        let index = Index::new(options, tmp).unwrap();
+        let mut wtxn = index.write_txn().unwrap();
+        let indexer_config = IndexerConfig::default();
+        let builder = IndexDocuments::new(
+            &mut wtxn,
+            &index,
+            &indexer_config,
+            IndexDocumentsConfig::default(),
+            |_| (),
+        )
+        .unwrap();
+
+        let doc1 = documents! {[{
+            "id": " 1",
+            "title": "asdsad",
+        }]};
+
+        let doc2 = documents! {[{
+            "id": "\t2",
+            "title": "something",
+        }]};
+
+        let doc3 = documents! {[{
+            "id": "\r3",
+            "title": "something",
+        }]};
+
+        let doc4 = documents! {[{
+            "id": "\n4",
+            "title": "something",
+        }]};
+
+        let (builder, user_error) = builder.add_documents(doc1).unwrap();
+        assert!(user_error.is_err());
+        let (builder, user_error) = builder.add_documents(doc2).unwrap();
+        assert!(user_error.is_err());
+        let (builder, user_error) = builder.add_documents(doc3).unwrap();
+        assert!(user_error.is_err());
+        let (_builder, user_error) = builder.add_documents(doc4).unwrap();
+        assert!(user_error.is_err());
+    }
 }


### PR DESCRIPTION
fix #592


related to https://github.com/meilisearch/meilisearch/issues/2640
