### PR TITLE
Speed up debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,16 @@ members = ["milli", "filter-parser", "flatten-serde-json", "json-depth-checker",
 default-members = ["milli"]
 
 [profile.dev]
-opt-level = 0
+opt-level = 0 
 
 [profile.release]
 debug = true
 codegen-units = 1
+
+[profile.dev.package.grenad]
+opt-level = 3
+[profile.dev.package.roaring]
+opt-level = 3
 
 [profile.dev.package.lindera-ipadic-builder]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,29 @@ members = ["milli", "filter-parser", "flatten-serde-json", "json-depth-checker",
 default-members = ["milli"]
 
 [profile.dev]
-opt-level = 3
+opt-level = 0
 
 [profile.release]
 debug = true
 codegen-units = 1
 
-# Make sure that the build scripts and proc-macros are compiled with
-# all the optimizations. It speeds up the zip crate that we use in the build.rs.
-[profile.dev.build-override]
+[profile.dev.package.lindera-ipadic-builder]
 opt-level = 3
-[profile.release.build-override]
+[profile.dev.package.encoding]
 opt-level = 3
-[profile.bench.build-override]
+[profile.dev.package.yada]
 opt-level = 3
-[profile.test.build-override]
+
+[profile.release.package.lindera-ipadic-builder]
+opt-level = 3
+[profile.release.package.encoding]
+opt-level = 3
+[profile.release.package.yada]
+opt-level = 3
+
+[profile.bench.package.lindera-ipadic-builder]
+opt-level = 3
+[profile.bench.package.encoding]
+opt-level = 3
+[profile.bench.package.yada]
 opt-level = 3

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.56"
 csv = "1.1.6"
-milli = { path = "../milli" }
+milli = { path = "../milli", default-features = false }
 mimalloc = { version = "0.1.29", default-features = false }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 
@@ -23,6 +23,9 @@ bytes = "1.1.0"
 convert_case = "0.5.0"
 flate2 = "1.0.22"
 reqwest = { version = "0.11.9", features = ["blocking", "rustls-tls"], default-features = false }
+
+[features]
+default = ["milli/default"]
 
 [[bench]]
 name = "search_songs"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,9 +12,12 @@ color-eyre = "0.6.1"
 csv = "1.1.6"
 eyre = "0.6.7"
 indicatif = "0.16.2"
-milli = { path = "../milli" }
+milli = { path = "../milli", default-features = false }
 mimalloc = { version = "0.1.29", default-features = false }
 serde = "1.0.136"
 serde_json = "1.0.79"
 stderrlog = "0.5.1"
 structopt = "0.3.26"
+
+[features]
+default = ["milli/default"]


### PR DESCRIPTION
Note: this draft PR is based on https://github.com/meilisearch/milli/pull/601 , for no particular reason.

## What does this PR do?
Make a series of changes with the goal of speeding up debug builds:

1. Add an `all_languages` feature which compiles charabia with its `default` features activated.
The `all_languages` feature is activated by default. But running:
```
cargo build --no-default-features
```
on `milli` is now much faster.

2. Reduce the debug optimisation level from 3 to 0, except for a few critical dependencies.

3.  Compile the build dependencies quicker as well. Previously, all build dependencies were compiled with `opt-level = 3`. Now, only the critical build dependencies are compiled with optimisations.

4. Reduce the amount of code generated by the `documents!` macro

5. Make the "progress update" closure provided to indexing functions a trait object instead of a generic parameter. This avoids monomorphising the indexing code multiple times needlessly.

## Results
Initial build times on my computer before and after these changes:
|        | cargo check | cargo check --no-default-features | cargo test | cargo test --lib | cargo test --no-default-features | cargo test --lib --no-default-features |
|--------|-------------|-----------------------------------|------------|------------------|----------------------------------|----------------------------------------|
| before | 1m05s       | 1m05s                             | 2m06s      | 1m47s            | 2m06                             | 1m47s                                  |
| after  | 28.9s       | 13.1s                             | 40s      | 38s            | 23s                              | 21s                                  |

