### PR TITLE
Make binaries faster on release profile through better compile options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ opt-level = 3
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "thin"
 
 # Make sure that the build scripts and proc-macros are compiled with
 # all the optimizations. It speeds up the zip crate that we use in the build.rs.


### PR DESCRIPTION
Using `codegen-units = 1` and `lto = 'thin'` makes the compile time a bit longer, but also produces faster binaries.

I'd like to run milli's benchmark with these options, so that we can see whether it is worth enabling on meilisearch.