### PR TITLE
Share heed between all sub-crates

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -13,7 +13,6 @@ serde_json = { version = "1.0.79", features = ["preserve_order"] }
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["html_reports"] }
-heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.1" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 roaring = "0.9.0"

--- a/milli/fuzz/Cargo.toml
+++ b/milli/fuzz/Cargo.toml
@@ -11,7 +11,6 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = "1.0"
 libfuzzer-sys = "0.4"
-heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.1" }
 serde_json = { version = "1.0.62", features = ["preserve_order"] }
 anyhow = "1.0"
 tempfile = "3.3"

--- a/milli/fuzz/fuzz_targets/indexing.rs
+++ b/milli/fuzz/fuzz_targets/indexing.rs
@@ -5,11 +5,11 @@ use std::io::{BufWriter, Cursor, Read, Seek, Write};
 
 use anyhow::{bail, Result};
 use arbitrary_json::ArbitraryValue;
-use heed::EnvOpenOptions;
 use libfuzzer_sys::fuzz_target;
 use milli::documents::{DocumentsBatchBuilder, DocumentsBatchReader};
+use milli::heed::EnvOpenOptions;
 use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig, Settings};
-use milli::Index;
+use milli::{Index, Object};
 use serde_json::{Map, Value};
 
 #[global_allocator]


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Use the reexported version of heed in the benchmarks and the fuzzer