### PR TITLE
Remove Bors required test for Windows

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
     'Tests on ubuntu-18.04',
     'Tests on macos-latest',
-    'Tests on windows-latest',
+    # 'Tests on windows-latest',
     'Run Rustfmt',
 ]
 # 3 hours timeout


### PR DESCRIPTION
Remove the required windows test for merging due to the issue with Lindera
https://github.com/meilisearch/milli/runs/7970141278?check_suite_focus=true