### PR TITLE
Add CI to update the Milli version

### DIFF
--- a/.github/workflows/update-cargo-toml-version.yml
+++ b/.github/workflows/update-cargo-toml-version.yml
@@ -1,0 +1,43 @@
+name: Update Milli version in all Cargo.toml files
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: 'The new version (vX.Y.Z)'
+        required: true
+
+env:
+  NEW_VERSION: ${{ github.event.inputs.new_version }}
+  GH_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
+
+jobs:
+  update-version-cargo-toml:
+    name: Update version in cargo.toml files
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install sd
+        run: cargo install sd
+      - name: Update files
+        run: |
+          echo "$GITHUB_REF_NAME"
+          raw_new_version=$(echo $NEW_VERSION | cut -d 'v' -f 2)
+          new_string="version = \"$raw_new_version\""
+          sd '^version = "\d+.\d+.\w+"$' "$new_string" */Cargo.toml
+      - name: Commits and push the changes to the ${{ github.ref_name }} branch
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Update version for the next release (${{ env.NEW_VERSION }}) in Cargo.toml files"
+          new_branch: update-version-${{ env.NEW_VERSION }}
+      - name: Create the PR
+        run: |
+          gh pr create \
+            --title "Update version for the next release ($NEW_VERSION) in Cargo.toml files" \
+            --body '⚠️ This PR is automatically generated. Check the new version is the expected one before merging.' \
+            --label 'skip changelog'


### PR DESCRIPTION
Add a CI we can trigger manually to create a PR updating the Milli version
The next step is to create a Slack bot that will trigger this CI
In the meantime, we can trigger this CI manually in the [Actions tab](https://github.com/meilisearch/milli/actions)

The `MEILI_BOT_GH_PAT` secrets has been added to the organization level, and is accessible for the following repositories (so far): Meilisearch, Milli and Charabia