### PR TITLE
Prevent windows and milli CI to run for PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
+    # if: github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'pull_request' && ${{ matrix.os }} == 'ubuntu-20.04')
+    if: github.event_name == 'schedule' || github.event_name == 'push'
     steps:
     - uses: actions/checkout@v3
     - name: Run test with Rust nightly
@@ -29,7 +31,6 @@ jobs:
         toolchain: nightly
         override: true
     - name: Run test with Rust stable
-      if: github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'pull_request' && ${{ matrix.os }} == 'ubuntu-20.04')
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Run test with Rust nightly
@@ -29,7 +29,7 @@ jobs:
         toolchain: nightly
         override: true
     - name: Run test with Rust stable
-      if: github.event_name != 'schedule'
+      if: github.event_name == 'schedule' || github.event_name == 'push' || (github.event_name == 'pull_request' && ${{ matrix.os }} == 'ubuntu-20.04')
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -50,7 +50,7 @@ jobs:
 
   fmt:
     name: Run Rustfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    'Tests on ubuntu-18.04',
+    'Tests on ubuntu-20.04',
     'Tests on macos-latest',
     # 'Tests on windows-latest',
     'Run Rustfmt',


### PR DESCRIPTION
windows and macos GitHub runner (provided by GitHub) are limited, and often we have to wait for the GitHub CI for the PR to have run before CI for bors merging the PR can start.