### PR TITLE
Revert "Remove Bors required test for Windows"

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
     'Tests on ubuntu-18.04',
     'Tests on macos-latest',
-    # 'Tests on windows-latest',
+    'Tests on windows-latest',
     'Run Rustfmt',
 ]
 # 3 hours timeout


### PR DESCRIPTION
Reverts meilisearch/milli#612

Because the issue does not seem to be there!

Closes https://github.com/meilisearch/milli/issues/614