### PR TITLE
Upgrade ubuntu-18.04 to 20.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Run test with Rust nightly
@@ -50,7 +50,7 @@ jobs:
 
   fmt:
     name: Run Rustfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    'Tests on ubuntu-18.04',
+    'Tests on ubuntu-20.04',
     'Tests on macos-latest',
     'Tests on windows-latest',
     'Run Rustfmt',


### PR DESCRIPTION
Ubuntu-18.04 is going to be deprecated by GitHub
https://github.com/actions/runner-images/issues/6002