### PR TITLE
Remove LTO in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ opt-level = 3
 [profile.release]
 debug = true
 codegen-units = 1
-lto = "thin"
 
 # Make sure that the build scripts and proc-macros are compiled with
 # all the optimizations. It speeds up the zip crate that we use in the build.rs.


### PR DESCRIPTION
Since we can't enable it in Meilisearch (see https://github.com/meilisearch/meilisearch/pull/2717 ), we should not enable it in milli either. The goal is for milli's benchmarks to accurately represent its performance within meilisearch.
