### PR TITLE
Enhance word splitting strategy

### DIFF
--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -146,7 +146,12 @@ impl fmt::Debug for Query {
 
 trait Context {
     fn word_docids(&self, word: &str) -> heed::Result<Option<RoaringBitmap>>;
-    fn word_pair_proximity_docids(&self, right_word: &str, left_word: &str, proximity: u8) -> heed::Result<Option<RoaringBitmap>>;
+    fn word_pair_proximity_docids(
+        &self,
+        right_word: &str,
+        left_word: &str,
+        proximity: u8,
+    ) -> heed::Result<Option<RoaringBitmap>>;
     fn synonyms<S: AsRef<str>>(&self, words: &[S]) -> heed::Result<Option<Vec<Vec<String>>>>;
     fn word_documents_count(&self, word: &str) -> heed::Result<Option<u64>> {
         match self.word_docids(word)? {
@@ -157,7 +162,12 @@ trait Context {
     /// Returns the minimum word len for 1 and 2 typos.
     fn min_word_len_for_typo(&self) -> heed::Result<(u8, u8)>;
     fn exact_words(&self) -> Option<&fst::Set<Cow<[u8]>>>;
-    fn word_pair_frequency(&self, left_word: &str, right_word: &str, proximity: u8) -> heed::Result<Option<u64>> {
+    fn word_pair_frequency(
+        &self,
+        left_word: &str,
+        right_word: &str,
+        proximity: u8,
+    ) -> heed::Result<Option<u64>> {
         match self.word_pair_proximity_docids(right_word, left_word, proximity)? {
             Some(rb) => Ok(Some(rb.len())),
             None => Ok(None),
@@ -180,7 +190,12 @@ impl<'a> Context for QueryTreeBuilder<'a> {
         self.index.word_docids.get(self.rtxn, word)
     }
 
-    fn word_pair_proximity_docids(&self, right_word: &str, left_word: &str, proximity: u8) -> heed::Result<Option<RoaringBitmap>> {
+    fn word_pair_proximity_docids(
+        &self,
+        right_word: &str,
+        left_word: &str,
+        proximity: u8,
+    ) -> heed::Result<Option<RoaringBitmap>> {
         self.index.word_pair_proximity_docids.get(self.rtxn, &(left_word, right_word, proximity))
     }
 
@@ -202,9 +217,17 @@ impl<'a> Context for QueryTreeBuilder<'a> {
         self.exact_words.as_ref()
     }
 
-    fn word_pair_frequency(&self, left_word: &str, right_word: &str, proximity: u8) -> heed::Result<Option<u64>> {
+    fn word_pair_frequency(
+        &self,
+        left_word: &str,
+        right_word: &str,
+        proximity: u8,
+    ) -> heed::Result<Option<u64>> {
         let key = (left_word, right_word, proximity);
-        self.index.word_pair_proximity_docids.remap_data_type::<CboRoaringBitmapLenCodec>().get(&self.rtxn, &key)
+        self.index
+            .word_pair_proximity_docids
+            .remap_data_type::<CboRoaringBitmapLenCodec>()
+            .get(&self.rtxn, &key)
     }
 }
 
@@ -838,7 +861,12 @@ mod test {
             Ok(self.postings.get(word).cloned())
         }
 
-        fn word_pair_proximity_docids(&self, right_word: &str, left_word: &str, _: u8) -> heed::Result<Option<RoaringBitmap>> {
+        fn word_pair_proximity_docids(
+            &self,
+            right_word: &str,
+            left_word: &str,
+            _: u8,
+        ) -> heed::Result<Option<RoaringBitmap>> {
             let bitmap = self.postings.get(&format!("{} {}", left_word, right_word));
             Ok(bitmap.cloned())
         }

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -160,7 +160,7 @@ trait Context {
         &self,
         left_word: &str,
         right_word: &str,
-        _proximity: u8,
+        proximity: u8,
     ) -> heed::Result<Option<u64>>;
 }
 
@@ -181,6 +181,10 @@ impl<'a> Context for QueryTreeBuilder<'a> {
 
     fn synonyms<S: AsRef<str>>(&self, words: &[S]) -> heed::Result<Option<Vec<Vec<String>>>> {
         self.index.words_synonyms(self.rtxn, words)
+    }
+
+    fn word_documents_count(&self, word: &str) -> heed::Result<Option<u64>> {
+        self.index.word_documents_count(self.rtxn, word)
     }
 
     fn min_word_len_for_typo(&self) -> heed::Result<(u8, u8)> {
@@ -511,7 +515,7 @@ fn create_query_tree(
                 .filter(|(_, part)| !part.is_phrase())
                 .max_by_key(|(_, part)| match part {
                     PrimitiveQueryPart::Word(s, _) => {
-                        ctx.word_documents_count(s).unwrap_or_default().unwrap_or(u64::max_value());
+                        ctx.word_documents_count(s).unwrap_or_default().unwrap_or(u64::max_value())
                     }
                     _ => unreachable!(),
                 })

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -510,7 +510,8 @@ fn create_query_tree(
                 .filter(|(_, part)| !part.is_phrase())
                 .max_by_key(|(_, part)| match part {
                     PrimitiveQueryPart::Word(s, _) => {
-                        let (pair_freq, _, _) = split_best_frequency(ctx, s).unwrap_or_default().unwrap_or_default();
+                        let (pair_freq, _, _) =
+                            split_best_frequency(ctx, s).unwrap_or_default().unwrap_or_default();
                         pair_freq
                     }
                     _ => unreachable!(),

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -155,12 +155,7 @@ trait Context {
         left_word: &str,
         right_word: &str,
         _proximity: u8,
-    ) -> heed::Result<Option<u64>> {
-        match self.word_docids(&format!("{} {}", left_word, right_word))? {
-            Some(rb) => Ok(Some(rb.len())),
-            None => Ok(None),
-        }
-    }
+    ) -> heed::Result<Option<u64>>;
 }
 
 /// The query tree builder is the interface to build a query tree.
@@ -849,6 +844,18 @@ mod test {
 
         fn exact_words(&self) -> Option<&fst::Set<Cow<[u8]>>> {
             self.exact_words.as_ref()
+        }
+
+        fn word_pair_frequency(
+            &self,
+            left_word: &str,
+            right_word: &str,
+            _proximity: u8,
+        ) -> heed::Result<Option<u64>> {
+            match self.word_docids(&format!("{} {}", left_word, right_word))? {
+                Some(rb) => Ok(Some(rb.len())),
+                None => Ok(None),
+            }
         }
     }
 

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -279,7 +279,7 @@ impl<'a> QueryTreeBuilder<'a> {
     }
 }
 
-/// Split the word depending on the frequency of subwords in the database documents.
+/// Split the word depending on the frequency of pairs near together in the database documents.
 fn split_best_frequency<'a>(
     ctx: &impl Context,
     word: &'a str,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #648 

## What does this PR do?
- [split_best_frequency](https://github.com/meilisearch/milli/blob/55d889522b8b5b6e3dc6d5cf8d14a4f7f62c956b/milli/src/search/query_tree.rs#L282-L301) to use frequency of word pairs near together with proximity value of 1 instead of considering the frequency of individual words. Word pairs having max frequency are considered.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!