### PR TITLE
Fix phrase search containing stop words

### DIFF
--- a/milli/src/search/criteria/attribute.rs
+++ b/milli/src/search/criteria/attribute.rs
@@ -579,6 +579,7 @@ fn flatten_query_tree(query_tree: &Operation) -> FlattenedQueryTree {
             Phrase(words) => {
                 let queries = words
                     .iter()
+                    .filter_map(|w| w.as_ref())
                     .map(|word| vec![Query { prefix: false, kind: QueryKind::exact(word.clone()) }])
                     .collect();
                 vec![queries]

--- a/milli/src/search/criteria/exactness.rs
+++ b/milli/src/search/criteria/exactness.rs
@@ -298,7 +298,7 @@ fn attribute_start_with_docids(
                 pos += 1;
             }
             Phrase(phrase) => {
-                for word in phrase {
+                for word in phrase.iter().filter_map(|w| w.as_ref()) {
                     let wc = ctx.word_position_docids(word, pos)?;
                     if let Some(word_candidates) = wc {
                         attribute_candidates_array.push(word_candidates);
@@ -323,7 +323,7 @@ fn intersection_of(mut rbs: Vec<&RoaringBitmap>) -> RoaringBitmap {
 
 #[derive(Debug, Clone)]
 pub enum ExactQueryPart {
-    Phrase(Vec<String>),
+    Phrase(Vec<Option<String>>),
     Synonyms(Vec<String>),
 }
 

--- a/milli/src/search/criteria/exactness.rs
+++ b/milli/src/search/criteria/exactness.rs
@@ -298,10 +298,12 @@ fn attribute_start_with_docids(
                 pos += 1;
             }
             Phrase(phrase) => {
-                for word in phrase.iter().filter_map(|w| w.as_ref()) {
-                    let wc = ctx.word_position_docids(word, pos)?;
-                    if let Some(word_candidates) = wc {
-                        attribute_candidates_array.push(word_candidates);
+                for word in phrase {
+                    if let Some(word) = word {
+                        let wc = ctx.word_position_docids(word, pos)?;
+                        if let Some(word_candidates) = wc {
+                            attribute_candidates_array.push(word_candidates);
+                        }
                     }
                     pos += 1;
                 }

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -425,7 +425,13 @@ pub fn resolve_phrase(ctx: &dyn Context, phrase: &[Option<String>]) -> Result<Ro
     for win in phrase.windows(winsize) {
         // Get all the documents with the matching distance for each word pairs.
         let mut bitmaps = Vec::with_capacity(winsize.pow(2));
-        for (offset, s1) in win.iter().filter_map(|w| w.as_ref()).enumerate() {
+        for (offset, s1) in win.iter().enumerate().filter_map(|(index, word)| {
+                if let Some(word) = word {
+                    Some((index, word))
+                } else {
+                    None
+                }
+            }) {
             for (dist, s2) in win.iter().skip(offset + 1).enumerate().filter_map(|(index, word)| {
                 if let Some(word) = word {
                     Some((index, word))

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -422,6 +422,11 @@ pub fn resolve_phrase(ctx: &dyn Context, phrase: &[Option<String>]) -> Result<Ro
     let mut candidates = RoaringBitmap::new();
     let mut first_iter = true;
     let winsize = phrase.len().min(3);
+
+    if phrase.is_empty() {
+        return Ok(candidates);
+    }
+
     for win in phrase.windows(winsize) {
         // Get all the documents with the matching distance for each word pairs.
         let mut bitmaps = Vec::with_capacity(winsize.pow(2));

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -426,12 +426,12 @@ pub fn resolve_phrase(ctx: &dyn Context, phrase: &[Option<String>]) -> Result<Ro
         // Get all the documents with the matching distance for each word pairs.
         let mut bitmaps = Vec::with_capacity(winsize.pow(2));
         for (offset, s1) in win.iter().enumerate().filter_map(|(index, word)| {
-                if let Some(word) = word {
-                    Some((index, word))
-                } else {
-                    None
-                }
-            }) {
+            if let Some(word) = word {
+                Some((index, word))
+            } else {
+                None
+            }
+        }) {
             for (dist, s2) in win.iter().skip(offset + 1).enumerate().filter_map(|(index, word)| {
                 if let Some(word) = word {
                     Some((index, word))

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -418,15 +418,21 @@ pub fn resolve_query_tree(
     resolve_operation(ctx, query_tree, wdcache)
 }
 
-pub fn resolve_phrase(ctx: &dyn Context, phrase: &[String]) -> Result<RoaringBitmap> {
+pub fn resolve_phrase(ctx: &dyn Context, phrase: &[Option<String>]) -> Result<RoaringBitmap> {
     let mut candidates = RoaringBitmap::new();
     let mut first_iter = true;
     let winsize = phrase.len().min(3);
     for win in phrase.windows(winsize) {
         // Get all the documents with the matching distance for each word pairs.
         let mut bitmaps = Vec::with_capacity(winsize.pow(2));
-        for (offset, s1) in win.iter().enumerate() {
-            for (dist, s2) in win.iter().skip(offset + 1).enumerate() {
+        for (offset, s1) in win.iter().filter_map(|w| w.as_ref()).enumerate() {
+            for (dist, s2) in win.iter().skip(offset + 1).enumerate().filter_map(|(index, word)| {
+                if let Some(word) = word {
+                    Some((index, word))
+                } else {
+                    None
+                }
+            }) {
                 if dist == 0 {
                     match ctx.word_pair_proximity_docids(s1, s2, 1)? {
                         Some(m) => bitmaps.push(m),

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -497,7 +497,7 @@ fn resolve_plane_sweep_candidates(
                         }
                     }
                     match subgroup.len() {
-                        0 => {},
+                        0 => {}
                         1 => groups_positions.push(subgroup.pop().unwrap()),
                         _ => groups_positions.push(plane_sweep(subgroup, true)?),
                     }

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -496,7 +496,11 @@ fn resolve_plane_sweep_candidates(
                             None => return Ok(vec![]),
                         }
                     }
-                    groups_positions.push(plane_sweep(subgroup, true)?);
+                    match subgroup.len() {
+                        0 => {},
+                        1 => groups_positions.push(subgroup.pop().unwrap()),
+                        _ => groups_positions.push(plane_sweep(subgroup, true)?),
+                    }
                 }
                 match groups_positions.len() {
                     0 => vec![],

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -187,14 +187,15 @@ fn resolve_candidates<'t>(
             Phrase(words) => {
                 if proximity == 0 {
                     let most_left = words
-                        .first()
-                        .map(|o| o.as_ref())
-                        .flatten()
+                        .iter()
+                        .filter_map(|o| o.as_ref())
+                        .next()
                         .map(|w| Query { prefix: false, kind: QueryKind::exact(w.clone()) });
                     let most_right = words
-                        .last()
-                        .map(|o| o.as_ref())
-                        .flatten()
+                        .iter()
+                        .rev()
+                        .filter_map(|o| o.as_ref())
+                        .next()
                         .map(|w| Query { prefix: false, kind: QueryKind::exact(w.clone()) });
 
                     match (most_left, most_right) {

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -478,14 +478,29 @@ fn resolve_plane_sweep_candidates(
             }
             Phrase(words) => {
                 let mut groups_positions = Vec::with_capacity(words.len());
-                for word in words.iter().filter_map(|w| w.as_ref()) {
-                    let positions = match words_positions.get(word) {
-                        Some(positions) => positions.iter().map(|p| (p, 0, p)).collect(),
-                        None => return Ok(vec![]),
-                    };
-                    groups_positions.push(positions);
+                let mut consecutive = true;
+                let mut was_last_word_a_stop_word = false;
+                for word in words.iter() {
+                    if let Some(word) = word {
+                        let positions = match words_positions.get(word) {
+                            Some(positions) => positions.iter().map(|p| (p, 0, p)).collect(),
+                            None => return Ok(vec![]),
+                        };
+                        groups_positions.push(positions);
+
+                        if was_last_word_a_stop_word {
+                            consecutive = false;
+                        }
+                        was_last_word_a_stop_word = false;
+                    } else {
+                        if !was_last_word_a_stop_word {
+                            consecutive = false;
+                        }
+
+                        was_last_word_a_stop_word = true;
+                    }
                 }
-                plane_sweep(groups_positions, true)?
+                plane_sweep(groups_positions, consecutive)?
             }
             Or(_, ops) => {
                 let mut result = Vec::new();

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -188,9 +188,13 @@ fn resolve_candidates<'t>(
                 if proximity == 0 {
                     let most_left = words
                         .first()
+                        .map(|o| o.as_ref())
+                        .flatten()
                         .map(|w| Query { prefix: false, kind: QueryKind::exact(w.clone()) });
                     let most_right = words
                         .last()
+                        .map(|o| o.as_ref())
+                        .flatten()
                         .map(|w| Query { prefix: false, kind: QueryKind::exact(w.clone()) });
 
                     match (most_left, most_right) {
@@ -473,7 +477,7 @@ fn resolve_plane_sweep_candidates(
             }
             Phrase(words) => {
                 let mut groups_positions = Vec::with_capacity(words.len());
-                for word in words {
+                for word in words.iter().filter_map(|w| w.as_ref()) {
                     let positions = match words_positions.get(word) {
                         Some(positions) => positions.iter().map(|p| (p, 0, p)).collect(),
                         None => return Ok(vec![]),

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::mem::take;
 
+use itertools::Itertools;
 use log::debug;
 use roaring::RoaringBitmap;
 
@@ -259,8 +260,7 @@ fn resolve_candidates<'t>(
             Phrase(words) => {
                 let mut candidates = RoaringBitmap::new();
                 let mut first_loop = true;
-                for slice in words.windows(2) {
-                    let (left, right) = (&slice[0], &slice[1]);
+                for (left, right) in words.iter().filter_map(|w| w.as_ref()).tuple_windows() {
                     match ctx.word_pair_proximity_docids(left, right, 1)? {
                         Some(pair_docids) => {
                             if pair_docids.is_empty() {

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -1081,7 +1081,7 @@ mod test {
         OR
           AND
             OR
-              PHRASE ["word", "split"]
+              PHRASE [Some("word"), Some("split")]
               Tolerant { word: "wordsplit", max typo: 2 }
             Exact { word: "fish" }
           Tolerant { word: "wordsplitfish", max typo: 1 }
@@ -1100,7 +1100,7 @@ mod test {
 
         insta::assert_debug_snapshot!(query_tree, @r###"
         OR
-          PHRASE ["quickbrown", "fox"]
+          PHRASE [Some("quickbrown"), Some("fox")]
           PrefixTolerant { word: "quickbrownfox", max typo: 2 }
         "###);
     }
@@ -1117,7 +1117,7 @@ mod test {
 
         insta::assert_debug_snapshot!(query_tree, @r###"
         AND
-          PHRASE ["hey", "friends"]
+          PHRASE [Some("hey"), Some("friends")]
           Exact { word: "wooop" }
         "###);
     }
@@ -1154,8 +1154,8 @@ mod test {
 
         insta::assert_debug_snapshot!(query_tree, @r###"
         AND
-          PHRASE ["hey", "friends"]
-          PHRASE ["wooop", "wooop"]
+          PHRASE [Some("hey"), Some("friends")]
+          PHRASE [Some("wooop"), Some("wooop")]
         "###);
     }
 
@@ -1203,7 +1203,7 @@ mod test {
             .unwrap();
 
         insta::assert_debug_snapshot!(query_tree, @r###"
-        PHRASE ["hey", "my"]
+        PHRASE [Some("hey"), Some("my")]
         "###);
     }
 
@@ -1268,7 +1268,7 @@ mod test {
 
         insta::assert_debug_snapshot!(query_tree, @r###"
         AND
-          PHRASE ["hey", "my"]
+          PHRASE [Some("hey"), Some("my")]
           Exact { word: "good" }
         "###);
     }

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -15,10 +15,10 @@ use slice_group_by::GroupBy;
 mod distinct;
 mod facet_distribution;
 mod filters;
+mod phrase_search;
 mod query_criteria;
 mod sort;
 mod typo_tolerance;
-mod phrase_search;
 
 pub const TEST_QUERY: &'static str = "hello world america";
 

--- a/milli/tests/search/mod.rs
+++ b/milli/tests/search/mod.rs
@@ -18,6 +18,7 @@ mod filters;
 mod query_criteria;
 mod sort;
 mod typo_tolerance;
+mod phrase_search;
 
 pub const TEST_QUERY: &'static str = "hello world america";
 

--- a/milli/tests/search/phrase_search.rs
+++ b/milli/tests/search/phrase_search.rs
@@ -10,7 +10,7 @@ fn set_stop_words(index: &Index, stop_words: &[&str]) {
     let mut builder = Settings::new(&mut wtxn, &index, &config);
     let stop_words = stop_words.into_iter().map(|s| s.to_string()).collect();
     builder.set_stop_words(stop_words);
-    builder.execute(|_| ()).unwrap();
+    builder.execute(|_| (), || false).unwrap();
     wtxn.commit().unwrap();
 }
 

--- a/milli/tests/search/phrase_search.rs
+++ b/milli/tests/search/phrase_search.rs
@@ -1,0 +1,35 @@
+use milli::update::{IndexerConfig, Settings};
+use milli::{Index, Search, TermsMatchingStrategy};
+
+fn set_stop_words(index: &Index, stop_words: &[&str]) {
+    let mut wtxn = index.write_txn().unwrap();
+    let config = IndexerConfig::default();
+
+    let mut builder = Settings::new(&mut wtxn, &index, &config);
+    let stop_words = stop_words.into_iter().map(|s| s.to_string()).collect();
+    builder.set_stop_words(stop_words);
+    builder.execute(|_| ()).unwrap();
+    wtxn.commit().unwrap();
+}
+
+#[test]
+fn test_phrase_search_with_stop_words() {
+    let criteria = [];
+    let index = super::setup_search_index_with_criteria(&criteria);
+
+    // Add stop_words
+    set_stop_words(&index, &["a", "an", "the", "of"]);
+
+    // Phrase search containing stop words
+    let txn = index.read_txn().unwrap();
+
+    let mut search = Search::new(&txn, &index);
+    search.query("\"the use of force\"");
+    search.limit(10);
+    search.authorize_typos(false);
+    search.terms_matching_strategy(TermsMatchingStrategy::All);
+
+    let result = search.execute().unwrap();
+    // 1 document should match
+    assert_eq!(result.documents_ids.len(), 1);
+}

--- a/milli/tests/search/phrase_search.rs
+++ b/milli/tests/search/phrase_search.rs
@@ -1,6 +1,7 @@
-use crate::search::Criterion::{Attribute, Exactness, Proximity};
 use milli::update::{IndexerConfig, Settings};
 use milli::{Criterion, Index, Search, TermsMatchingStrategy};
+
+use crate::search::Criterion::{Attribute, Exactness, Proximity};
 
 fn set_stop_words(index: &Index, stop_words: &[&str]) {
     let mut wtxn = index.write_txn().unwrap();

--- a/milli/tests/search/phrase_search.rs
+++ b/milli/tests/search/phrase_search.rs
@@ -32,4 +32,13 @@ fn test_phrase_search_with_stop_words() {
     let result = search.execute().unwrap();
     // 1 document should match
     assert_eq!(result.documents_ids.len(), 1);
+
+    // test for a single stop word only, no other search terms
+    let mut search = Search::new(&txn, &index);
+    search.query("\"the\"");
+    search.limit(10);
+    search.authorize_typos(false);
+    search.terms_matching_strategy(TermsMatchingStrategy::All);
+    let result = search.execute().unwrap();
+    assert_eq!(result.documents_ids.len(), 0);
 }

--- a/milli/tests/search/phrase_search.rs
+++ b/milli/tests/search/phrase_search.rs
@@ -1,5 +1,6 @@
+use crate::search::Criterion::{Attribute, Exactness, Proximity};
 use milli::update::{IndexerConfig, Settings};
-use milli::{Index, Search, TermsMatchingStrategy};
+use milli::{Criterion, Index, Search, TermsMatchingStrategy};
 
 fn set_stop_words(index: &Index, stop_words: &[&str]) {
     let mut wtxn = index.write_txn().unwrap();
@@ -12,9 +13,7 @@ fn set_stop_words(index: &Index, stop_words: &[&str]) {
     wtxn.commit().unwrap();
 }
 
-#[test]
-fn test_phrase_search_with_stop_words() {
-    let criteria = [];
+fn test_phrase_search_with_stop_words_given_criteria(criteria: &[Criterion]) {
     let index = super::setup_search_index_with_criteria(&criteria);
 
     // Add stop_words
@@ -41,4 +40,16 @@ fn test_phrase_search_with_stop_words() {
     search.terms_matching_strategy(TermsMatchingStrategy::All);
     let result = search.execute().unwrap();
     assert_eq!(result.documents_ids.len(), 0);
+}
+
+#[test]
+fn test_phrase_search_with_stop_words_no_criteria() {
+    let criteria = [];
+    test_phrase_search_with_stop_words_given_criteria(&criteria);
+}
+
+#[test]
+fn test_phrase_search_with_stop_words_all_criteria() {
+    let criteria = [Proximity, Attribute, Exactness];
+    test_phrase_search_with_stop_words_given_criteria(&criteria);
 }


### PR DESCRIPTION
# Pull Request

This a WIP draft PR I wanted to create to let other potential contributors know that I'm working on this issue. I'll be completing this in a few hours from opening this.

## Related issue
Fixes #661 and towards fixing meilisearch/meilisearch#2905

## What does this PR do?
- [x] Change Phrase Operation to use a `Vec<Option<String>>` instead of `Vec<String>` where `None` corresponds to a stop word
- [x] Update all other uses of phrase operation
- [x] Update `resolve_phrase`
- [x] Update `create_primitive_query`?
- [x] Add test

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
