### PR TITLE
Fix many Clippy errors part 2

### DIFF
--- a/milli/src/asc_desc.rs
+++ b/milli/src/asc_desc.rs
@@ -70,7 +70,7 @@ impl FromStr for Member {
     type Err = AscDescError;
 
     fn from_str(text: &str) -> Result<Member, Self::Err> {
-        match text.strip_prefix("_geoPoint(").and_then(|text| text.strip_suffix(")")) {
+        match text.strip_prefix("_geoPoint(").and_then(|text| text.strip_suffix(')')) {
             Some(point) => {
                 let (lat, lng) = point
                     .split_once(',')

--- a/milli/src/documents/builder.rs
+++ b/milli/src/documents/builder.rs
@@ -60,7 +60,7 @@ impl<W: Write> DocumentsBatchBuilder<W> {
     /// Appends a new JSON object into the batch and updates the `DocumentsBatchIndex` accordingly.
     pub fn append_json_object(&mut self, object: &Object) -> io::Result<()> {
         // Make sure that we insert the fields ids in order as the obkv writer has this requirement.
-        let mut fields_ids: Vec<_> = object.keys().map(|k| self.fields_index.insert(&k)).collect();
+        let mut fields_ids: Vec<_> = object.keys().map(|k| self.fields_index.insert(k)).collect();
         fields_ids.sort_unstable();
 
         self.obkv_buffer.clear();

--- a/milli/src/documents/mod.rs
+++ b/milli/src/documents/mod.rs
@@ -25,9 +25,9 @@ const DOCUMENTS_BATCH_INDEX_KEY: [u8; 8] = u64::MAX.to_be_bytes();
 pub fn obkv_to_object(obkv: &KvReader<FieldId>, index: &DocumentsBatchIndex) -> Result<Object> {
     obkv.iter()
         .map(|(field_id, value)| {
-            let field_name = index.name(field_id).ok_or_else(|| {
-                FieldIdMapMissingEntry::FieldId { field_id, process: "obkv_to_object" }
-            })?;
+            let field_name = index
+                .name(field_id)
+                .ok_or(FieldIdMapMissingEntry::FieldId { field_id, process: "obkv_to_object" })?;
             let value = serde_json::from_slice(value).map_err(InternalError::SerdeJson)?;
             Ok((field_name.to_string(), value))
         })

--- a/milli/src/fields_ids_map.rs
+++ b/milli/src/fields_ids_map.rs
@@ -65,7 +65,7 @@ impl FieldsIdsMap {
     }
 
     /// Iterate over the ids in the order of the ids.
-    pub fn ids<'a>(&'a self) -> impl Iterator<Item = FieldId> + 'a {
+    pub fn ids(&'_ self) -> impl Iterator<Item = FieldId> + '_ {
         self.ids_names.keys().copied()
     }
 

--- a/milli/src/heed_codec/facet/facet_string_level_zero_value_codec.rs
+++ b/milli/src/heed_codec/facet/facet_string_level_zero_value_codec.rs
@@ -34,7 +34,7 @@ where
     type EItem = (&'a str, C::EItem);
 
     fn bytes_encode((string, value): &'a Self::EItem) -> Option<Cow<[u8]>> {
-        let value_bytes = C::bytes_encode(&value)?;
+        let value_bytes = C::bytes_encode(value)?;
 
         let mut bytes = Vec::with_capacity(2 + string.len() + value_bytes.len());
         encode_prefix_string(string, &mut bytes).ok()?;

--- a/milli/src/heed_codec/facet/facet_string_zero_bounds_value_codec.rs
+++ b/milli/src/heed_codec/facet/facet_string_zero_bounds_value_codec.rs
@@ -66,14 +66,14 @@ where
                 bytes.extend_from_slice(left.as_bytes());
                 bytes.extend_from_slice(right.as_bytes());
 
-                let value_bytes = C::bytes_encode(&value)?;
+                let value_bytes = C::bytes_encode(value)?;
                 bytes.extend_from_slice(&value_bytes[..]);
 
                 Some(Cow::Owned(bytes))
             }
             None => {
                 bytes.push(0);
-                let value_bytes = C::bytes_encode(&value)?;
+                let value_bytes = C::bytes_encode(value)?;
                 bytes.extend_from_slice(&value_bytes[..]);
                 Some(Cow::Owned(bytes))
             }

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -320,7 +320,7 @@ impl Index {
     /// Writes the documents primary key, this is the field name that is used to store the id.
     pub(crate) fn put_primary_key(&self, wtxn: &mut RwTxn, primary_key: &str) -> heed::Result<()> {
         self.set_updated_at(wtxn, &OffsetDateTime::now_utc())?;
-        self.main.put::<_, Str, Str>(wtxn, main_key::PRIMARY_KEY_KEY, &primary_key)
+        self.main.put::<_, Str, Str>(wtxn, main_key::PRIMARY_KEY_KEY, primary_key)
     }
 
     /// Deletes the primary key of the documents, this can be done to reset indexes settings.
@@ -1013,7 +1013,7 @@ impl Index {
             let kv = self
                 .documents
                 .get(rtxn, &BEU32::new(id))?
-                .ok_or_else(|| UserError::UnknownInternalDocumentId { document_id: id })?;
+                .ok_or(UserError::UnknownInternalDocumentId { document_id: id })?;
             documents.push((id, kv));
         }
 
@@ -1072,7 +1072,7 @@ impl Index {
         wtxn: &mut RwTxn,
         time: &OffsetDateTime,
     ) -> heed::Result<()> {
-        self.main.put::<_, Str, SerdeJson<OffsetDateTime>>(wtxn, main_key::UPDATED_AT_KEY, &time)
+        self.main.put::<_, Str, SerdeJson<OffsetDateTime>>(wtxn, main_key::UPDATED_AT_KEY, time)
     }
 
     pub fn authorize_typos(&self, txn: &RoTxn) -> heed::Result<bool> {

--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -200,7 +200,7 @@ impl Index {
 
     pub fn new<P: AsRef<Path>>(options: heed::EnvOpenOptions, path: P) -> Result<Index> {
         let now = OffsetDateTime::now_utc();
-        Self::new_with_creation_dates(options, path, now.clone(), now)
+        Self::new_with_creation_dates(options, path, now, now)
     }
 
     fn set_creation_dates(

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::reversed_empty_ranges)]
+#![allow(clippy::too_many_arguments)]
 #[macro_use]
 pub mod documents;
 

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::reversed_empty_ranges)]
 #[macro_use]
 pub mod documents;
 

--- a/milli/src/search/criteria/asc_desc.rs
+++ b/milli/src/search/criteria/asc_desc.rs
@@ -115,7 +115,7 @@ impl<'t> Criterion for AscDesc<'t> {
                         let mut candidates = match (&self.query_tree, candidates) {
                             (_, Some(candidates)) => candidates,
                             (Some(qt), None) => {
-                                let context = CriteriaBuilder::new(&self.rtxn, &self.index)?;
+                                let context = CriteriaBuilder::new(self.rtxn, self.index)?;
                                 resolve_query_tree(&context, qt, params.wdcache)?
                             }
                             (None, None) => self.index.documents_ids(self.rtxn)?,

--- a/milli/src/search/criteria/geo.rs
+++ b/milli/src/search/criteria/geo.rs
@@ -90,7 +90,7 @@ impl Criterion for Geo<'_> {
                         let mut candidates = match (&query_tree, candidates) {
                             (_, Some(candidates)) => candidates,
                             (Some(qt), None) => {
-                                let context = CriteriaBuilder::new(&self.rtxn, &self.index)?;
+                                let context = CriteriaBuilder::new(self.rtxn, self.index)?;
                                 resolve_query_tree(&context, qt, params.wdcache)?
                             }
                             (None, None) => self.index.documents_ids(self.rtxn)?,

--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -44,7 +44,7 @@ impl<D: Distinct> Criterion for Initial<'_, D> {
                     let mut candidates = resolve_query_tree(
                         self.ctx,
                         answer.query_tree.as_ref().unwrap(),
-                        &mut params.wdcache,
+                        params.wdcache,
                     )?;
 
                     // Apply the filters on the documents retrieved with the query tree.

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -562,11 +562,11 @@ fn query_pair_proximity_docids(
                 )? {
                     Some(docids) => Ok(docids),
                     None => {
-                        let r_words = word_derivations(&right, true, 0, ctx.words_fst(), wdcache)?;
+                        let r_words = word_derivations(right, true, 0, ctx.words_fst(), wdcache)?;
                         all_word_pair_overall_proximity_docids(
                             ctx,
                             &[(left, 0)],
-                            &r_words,
+                            r_words,
                             proximity,
                         )
                     }
@@ -592,11 +592,11 @@ fn query_pair_proximity_docids(
                         Some(docids) => Ok(docids),
                         None => {
                             let r_words =
-                                word_derivations(&right, true, 0, ctx.words_fst(), wdcache)?;
+                                word_derivations(right, true, 0, ctx.words_fst(), wdcache)?;
                             all_word_pair_overall_proximity_docids(
                                 ctx,
                                 &[(left, 0)],
-                                &r_words,
+                                r_words,
                                 proximity,
                             )
                         }
@@ -609,17 +609,17 @@ fn query_pair_proximity_docids(
             }
         }
         (QueryKind::Exact { word: left, .. }, QueryKind::Tolerant { typo, word: right }) => {
-            let r_words = word_derivations(&right, prefix, *typo, ctx.words_fst(), wdcache)?;
-            all_word_pair_overall_proximity_docids(ctx, &[(left, 0)], &r_words, proximity)
+            let r_words = word_derivations(right, prefix, *typo, ctx.words_fst(), wdcache)?;
+            all_word_pair_overall_proximity_docids(ctx, &[(left, 0)], r_words, proximity)
         }
         (
             QueryKind::Tolerant { typo: l_typo, word: left },
             QueryKind::Tolerant { typo: r_typo, word: right },
         ) => {
             let l_words =
-                word_derivations(&left, false, *l_typo, ctx.words_fst(), wdcache)?.to_owned();
-            let r_words = word_derivations(&right, prefix, *r_typo, ctx.words_fst(), wdcache)?;
-            all_word_pair_overall_proximity_docids(ctx, &l_words, &r_words, proximity)
+                word_derivations(left, false, *l_typo, ctx.words_fst(), wdcache)?.to_owned();
+            let r_words = word_derivations(right, prefix, *r_typo, ctx.words_fst(), wdcache)?;
+            all_word_pair_overall_proximity_docids(ctx, &l_words, r_words, proximity)
         }
     }
 }

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -186,19 +186,19 @@ impl<'c> Context<'c> for CriteriaBuilder<'c> {
     }
 
     fn word_docids(&self, word: &str) -> heed::Result<Option<RoaringBitmap>> {
-        self.index.word_docids.get(self.rtxn, &word)
+        self.index.word_docids.get(self.rtxn, word)
     }
 
     fn exact_word_docids(&self, word: &str) -> heed::Result<Option<RoaringBitmap>> {
-        self.index.exact_word_docids.get(self.rtxn, &word)
+        self.index.exact_word_docids.get(self.rtxn, word)
     }
 
     fn word_prefix_docids(&self, word: &str) -> heed::Result<Option<RoaringBitmap>> {
-        self.index.word_prefix_docids.get(self.rtxn, &word)
+        self.index.word_prefix_docids.get(self.rtxn, word)
     }
 
     fn exact_word_prefix_docids(&self, word: &str) -> heed::Result<Option<RoaringBitmap>> {
-        self.index.exact_word_prefix_docids.get(self.rtxn, &word)
+        self.index.exact_word_prefix_docids.get(self.rtxn, word)
     }
 
     fn word_pair_proximity_docids(
@@ -321,7 +321,7 @@ impl<'t> CriteriaBuilder<'t> {
             exhaustive_number_hits,
             distinct,
         )) as Box<dyn Criterion>;
-        for name in self.index.criteria(&self.rtxn)? {
+        for name in self.index.criteria(self.rtxn)? {
             criterion = match name {
                 Name::Words => Box::new(Words::new(self, criterion)),
                 Name::Typo => Box::new(Typo::new(self, criterion)),
@@ -330,29 +330,23 @@ impl<'t> CriteriaBuilder<'t> {
                         for asc_desc in sort_criteria {
                             criterion = match asc_desc {
                                 AscDescName::Asc(Member::Field(field)) => Box::new(AscDesc::asc(
-                                    &self.index,
-                                    &self.rtxn,
+                                    self.index,
+                                    self.rtxn,
                                     criterion,
                                     field.to_string(),
                                 )?),
                                 AscDescName::Desc(Member::Field(field)) => Box::new(AscDesc::desc(
-                                    &self.index,
-                                    &self.rtxn,
+                                    self.index,
+                                    self.rtxn,
                                     criterion,
                                     field.to_string(),
                                 )?),
-                                AscDescName::Asc(Member::Geo(point)) => Box::new(Geo::asc(
-                                    &self.index,
-                                    &self.rtxn,
-                                    criterion,
-                                    point.clone(),
-                                )?),
-                                AscDescName::Desc(Member::Geo(point)) => Box::new(Geo::desc(
-                                    &self.index,
-                                    &self.rtxn,
-                                    criterion,
-                                    point.clone(),
-                                )?),
+                                AscDescName::Asc(Member::Geo(point)) => {
+                                    Box::new(Geo::asc(self.index, self.rtxn, criterion, *point)?)
+                                }
+                                AscDescName::Desc(Member::Geo(point)) => {
+                                    Box::new(Geo::desc(self.index, self.rtxn, criterion, *point)?)
+                                }
                             };
                         }
                         criterion
@@ -363,10 +357,10 @@ impl<'t> CriteriaBuilder<'t> {
                 Name::Attribute => Box::new(Attribute::new(self, criterion)),
                 Name::Exactness => Box::new(Exactness::new(self, criterion, &primitive_query)?),
                 Name::Asc(field) => {
-                    Box::new(AscDesc::asc(&self.index, &self.rtxn, criterion, field)?)
+                    Box::new(AscDesc::asc(self.index, self.rtxn, criterion, field)?)
                 }
                 Name::Desc(field) => {
-                    Box::new(AscDesc::desc(&self.index, &self.rtxn, criterion, field)?)
+                    Box::new(AscDesc::desc(self.index, self.rtxn, criterion, field)?)
                 }
             };
         }
@@ -408,7 +402,7 @@ pub fn resolve_query_tree(
                 }
                 Ok(candidates)
             }
-            Phrase(words) => resolve_phrase(ctx, &words),
+            Phrase(words) => resolve_phrase(ctx, words),
             Or(_, ops) => {
                 let mut candidates = RoaringBitmap::new();
                 for op in ops {
@@ -457,7 +451,7 @@ pub fn resolve_phrase(ctx: &dyn Context, phrase: &[String]) -> Result<RoaringBit
         }
 
         // We sort the bitmaps so that we perform the small intersections first, which is faster.
-        bitmaps.sort_unstable_by(|a, b| a.len().cmp(&b.len()));
+        bitmaps.sort_unstable_by_key(|a| a.len());
 
         for bitmap in bitmaps {
             if first_iter {
@@ -500,40 +494,40 @@ fn query_docids(
 ) -> Result<RoaringBitmap> {
     match &query.kind {
         QueryKind::Exact { word, original_typo } => {
-            if query.prefix && ctx.in_prefix_cache(&word) {
-                let mut docids = ctx.word_prefix_docids(&word)?.unwrap_or_default();
+            if query.prefix && ctx.in_prefix_cache(word) {
+                let mut docids = ctx.word_prefix_docids(word)?.unwrap_or_default();
                 // only add the exact docids if the word hasn't been derived
                 if *original_typo == 0 {
-                    docids |= ctx.exact_word_prefix_docids(&word)?.unwrap_or_default();
+                    docids |= ctx.exact_word_prefix_docids(word)?.unwrap_or_default();
                 }
                 Ok(docids)
             } else if query.prefix {
-                let words = word_derivations(&word, true, 0, ctx.words_fst(), wdcache)?;
+                let words = word_derivations(word, true, 0, ctx.words_fst(), wdcache)?;
                 let mut docids = RoaringBitmap::new();
                 for (word, _typo) in words {
-                    docids |= ctx.word_docids(&word)?.unwrap_or_default();
+                    docids |= ctx.word_docids(word)?.unwrap_or_default();
                     // only add the exact docids if the word hasn't been derived
                     if *original_typo == 0 {
-                        docids |= ctx.exact_word_docids(&word)?.unwrap_or_default();
+                        docids |= ctx.exact_word_docids(word)?.unwrap_or_default();
                     }
                 }
                 Ok(docids)
             } else {
-                let mut docids = ctx.word_docids(&word)?.unwrap_or_default();
+                let mut docids = ctx.word_docids(word)?.unwrap_or_default();
                 // only add the exact docids if the word hasn't been derived
                 if *original_typo == 0 {
-                    docids |= ctx.exact_word_docids(&word)?.unwrap_or_default();
+                    docids |= ctx.exact_word_docids(word)?.unwrap_or_default();
                 }
                 Ok(docids)
             }
         }
         QueryKind::Tolerant { typo, word } => {
-            let words = word_derivations(&word, query.prefix, *typo, ctx.words_fst(), wdcache)?;
+            let words = word_derivations(word, query.prefix, *typo, ctx.words_fst(), wdcache)?;
             let mut docids = RoaringBitmap::new();
             for (word, typo) in words {
-                let mut current_docids = ctx.word_docids(&word)?.unwrap_or_default();
+                let mut current_docids = ctx.word_docids(word)?.unwrap_or_default();
                 if *typo == 0 {
-                    current_docids |= ctx.exact_word_docids(&word)?.unwrap_or_default()
+                    current_docids |= ctx.exact_word_docids(word)?.unwrap_or_default()
                 }
                 docids |= current_docids;
             }
@@ -585,7 +579,7 @@ fn query_pair_proximity_docids(
         }
         (QueryKind::Tolerant { typo, word: left }, QueryKind::Exact { word: right, .. }) => {
             let l_words =
-                word_derivations(&left, false, *typo, ctx.words_fst(), wdcache)?.to_owned();
+                word_derivations(left, false, *typo, ctx.words_fst(), wdcache)?.to_owned();
             if prefix {
                 let mut docids = RoaringBitmap::new();
                 for (left, _) in l_words {

--- a/milli/src/search/criteria/proximity.rs
+++ b/milli/src/search/criteria/proximity.rs
@@ -99,7 +99,7 @@ impl<'t> Criterion for Proximity<'t> {
                         // use set theory based algorithm
                         resolve_candidates(
                             self.ctx,
-                            &query_tree,
+                            query_tree,
                             self.proximity,
                             &mut self.candidates_cache,
                             params.wdcache,
@@ -194,7 +194,7 @@ fn resolve_candidates<'t>(
                         .map(|w| Query { prefix: false, kind: QueryKind::exact(w.clone()) });
 
                     match (most_left, most_right) {
-                        (Some(l), Some(r)) => vec![(l, r, resolve_phrase(ctx, &words)?)],
+                        (Some(l), Some(r)) => vec![(l, r, resolve_phrase(ctx, words)?)],
                         _otherwise => Default::default(),
                     }
                 } else {
@@ -496,7 +496,7 @@ fn resolve_plane_sweep_candidates(
                 match kind {
                     QueryKind::Exact { word, .. } => {
                         if *prefix {
-                            let iter = word_derivations(word, true, 0, &words_positions)
+                            let iter = word_derivations(word, true, 0, words_positions)
                                 .flat_map(|positions| positions.iter().map(|p| (p, 0, p)));
                             result.extend(iter);
                         } else if let Some(positions) = words_positions.get(word) {
@@ -504,7 +504,7 @@ fn resolve_plane_sweep_candidates(
                         }
                     }
                     QueryKind::Tolerant { typo, word } => {
-                        let iter = word_derivations(word, *prefix, *typo, &words_positions)
+                        let iter = word_derivations(word, *prefix, *typo, words_positions)
                             .flat_map(|positions| positions.iter().map(|p| (p, 0, p)));
                         result.extend(iter);
                     }

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -69,7 +69,7 @@ impl<'t> Criterion for Typo<'t> {
                     let fst = self.ctx.words_fst();
                     let new_query_tree = match self.typos {
                         typos if typos < MAX_TYPOS_PER_WORD => alterate_query_tree(
-                            &fst,
+                            fst,
                             query_tree.clone(),
                             self.typos,
                             params.wdcache,
@@ -78,7 +78,7 @@ impl<'t> Criterion for Typo<'t> {
                             // When typos >= MAX_TYPOS_PER_WORD, no more alteration of the query tree is possible,
                             // we keep the altered query tree
                             *query_tree = alterate_query_tree(
-                                &fst,
+                                fst,
                                 query_tree.clone(),
                                 self.typos,
                                 params.wdcache,
@@ -199,7 +199,7 @@ fn alterate_query_tree(
                 ops.iter_mut().try_for_each(|op| recurse(words_fst, op, number_typos, wdcache))
             }
             // Because Phrases don't allow typos, no alteration can be done.
-            Phrase(_words) => return Ok(()),
+            Phrase(_words) => Ok(()),
             Operation::Query(q) => {
                 if let QueryKind::Tolerant { typo, word } = &q.kind {
                     // if no typo is allowed we don't call word_derivations function,

--- a/milli/src/search/criteria/words.rs
+++ b/milli/src/search/criteria/words.rs
@@ -53,10 +53,7 @@ impl<'t> Criterion for Words<'t> {
                         None => None,
                     };
 
-                    let bucket_candidates = match self.bucket_candidates.as_mut() {
-                        Some(bucket_candidates) => Some(take(bucket_candidates)),
-                        None => None,
-                    };
+                    let bucket_candidates = self.bucket_candidates.as_mut().map(take);
 
                     return Ok(Some(CriterionResult {
                         query_tree: Some(query_tree),

--- a/milli/src/search/facet/facet_distribution.rs
+++ b/milli/src/search/facet/facet_distribution.rs
@@ -66,7 +66,7 @@ impl<'a> FacetDistribution<'a> {
     ) -> heed::Result<()> {
         match facet_type {
             FacetType::Number => {
-                let mut key_buffer: Vec<_> = field_id.to_be_bytes().iter().copied().collect();
+                let mut key_buffer: Vec<_> = field_id.to_be_bytes().to_vec();
 
                 let distribution_prelength = distribution.len();
                 let db = self.index.field_id_docid_facet_f64s;
@@ -91,7 +91,7 @@ impl<'a> FacetDistribution<'a> {
             }
             FacetType::String => {
                 let mut normalized_distribution = BTreeMap::new();
-                let mut key_buffer: Vec<_> = field_id.to_be_bytes().iter().copied().collect();
+                let mut key_buffer: Vec<_> = field_id.to_be_bytes().to_vec();
 
                 let db = self.index.field_id_docid_facet_strings;
                 for docid in candidates.into_iter() {

--- a/milli/src/search/matches/matching_words.rs
+++ b/milli/src/search/matches/matching_words.rs
@@ -44,7 +44,7 @@ impl<'a> Iterator for MatchesIter<'a, '_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.next() {
-            Some((matching_words, ids)) => match matching_words[0].match_token(&self.token) {
+            Some((matching_words, ids)) => match matching_words[0].match_token(self.token) {
                 Some(char_len) => {
                     if matching_words.len() > 1 {
                         Some(MatchType::Partial(PartialMatch {

--- a/milli/src/search/matches/mod.rs
+++ b/milli/src/search/matches/mod.rs
@@ -49,16 +49,16 @@ impl<'a, A> MatcherBuilder<'a, A> {
     pub fn build<'t, 'm>(&'m self, text: &'t str) -> Matcher<'t, 'm, A> {
         let crop_marker = match &self.crop_marker {
             Some(marker) => marker.as_str(),
-            None => &DEFAULT_CROP_MARKER,
+            None => DEFAULT_CROP_MARKER,
         };
 
         let highlight_prefix = match &self.highlight_prefix {
             Some(marker) => marker.as_str(),
-            None => &DEFAULT_HIGHLIGHT_PREFIX,
+            None => DEFAULT_HIGHLIGHT_PREFIX,
         };
         let highlight_suffix = match &self.highlight_suffix {
             Some(marker) => marker.as_str(),
-            None => &DEFAULT_HIGHLIGHT_SUFFIX,
+            None => DEFAULT_HIGHLIGHT_SUFFIX,
         };
         Matcher {
             text,
@@ -95,7 +95,7 @@ pub struct Match {
     token_position: usize,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct MatchBounds {
     pub start: usize,
     pub length: usize,
@@ -131,7 +131,7 @@ impl<'t, A: AsRef<[u8]>> Matcher<'t, '_, A> {
             potential_matches.push((token_position, word_position, partial.char_len()));
 
             for (token_position, word_position, word) in words_positions {
-                partial = match partial.match_token(&word) {
+                partial = match partial.match_token(word) {
                     // token matches the partial match, but the match is not full,
                     // we temporarly save the current token then we try to match the next one.
                     Some(MatchType::Partial(partial)) => {

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -313,7 +313,7 @@ pub struct TypoConfig<'a> {
 
 /// Return the `QueryKind` of a word depending on `authorize_typos`
 /// and the provided word length.
-fn typos(word: String, authorize_typos: bool, config: TypoConfig<'_>) -> QueryKind {
+fn typos(word: String, authorize_typos: bool, config: TypoConfig) -> QueryKind {
     if authorize_typos && !config.exact_words.map_or(false, |s| s.contains(&word)) {
         let count = word.chars().count().min(u8::MAX as usize) as u8;
         if count < config.word_len_one_typo {

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -188,8 +188,8 @@ impl<'a> Context for QueryTreeBuilder<'a> {
     }
 
     fn min_word_len_for_typo(&self) -> heed::Result<(u8, u8)> {
-        let one = self.index.min_word_len_one_typo(&self.rtxn)?;
-        let two = self.index.min_word_len_two_typos(&self.rtxn)?;
+        let one = self.index.min_word_len_one_typo(self.rtxn)?;
+        let two = self.index.min_word_len_two_typos(self.rtxn)?;
         Ok((one, two))
     }
 
@@ -207,7 +207,7 @@ impl<'a> Context for QueryTreeBuilder<'a> {
         self.index
             .word_pair_proximity_docids
             .remap_data_type::<CboRoaringBitmapLenCodec>()
-            .get(&self.rtxn, &key)
+            .get(self.rtxn, &key)
     }
 }
 
@@ -313,7 +313,7 @@ pub struct TypoConfig<'a> {
 
 /// Return the `QueryKind` of a word depending on `authorize_typos`
 /// and the provided word length.
-fn typos<'a>(word: String, authorize_typos: bool, config: TypoConfig<'a>) -> QueryKind {
+fn typos(word: String, authorize_typos: bool, config: TypoConfig<'_>) -> QueryKind {
     if authorize_typos && !config.exact_words.map_or(false, |s| s.contains(&word)) {
         let count = word.chars().count().min(u8::MAX as usize) as u8;
         if count < config.word_len_one_typo {
@@ -556,7 +556,7 @@ fn create_matching_words(
                     for synonym in synonyms {
                         let synonym = synonym
                             .into_iter()
-                            .map(|syn| MatchingWord::new(syn.to_string(), 0, false))
+                            .map(|syn| MatchingWord::new(syn, 0, false))
                             .collect();
                         matching_words.push((synonym, vec![id]));
                     }
@@ -583,8 +583,7 @@ fn create_matching_words(
             PrimitiveQueryPart::Phrase(words) => {
                 let ids: Vec<_> =
                     (0..words.len()).into_iter().map(|i| id + i as PrimitiveWordId).collect();
-                let words =
-                    words.into_iter().map(|w| MatchingWord::new(w.to_string(), 0, false)).collect();
+                let words = words.into_iter().map(|w| MatchingWord::new(w, 0, false)).collect();
                 matching_words.push((words, ids));
             }
         }
@@ -639,7 +638,7 @@ fn create_matching_words(
                                 for synonym in synonyms {
                                     let synonym = synonym
                                         .into_iter()
-                                        .map(|syn| MatchingWord::new(syn.to_string(), 0, false))
+                                        .map(|syn| MatchingWord::new(syn, 0, false))
                                         .collect();
                                     matching_words.push((synonym, ids.clone()));
                                 }

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -262,8 +262,8 @@ impl<'t, 'u, 'i> Facets<'t, 'u, 'i> {
 /// 1. a vector of grenad::Reader. The reader at index `i` corresponds to the elements of level `i + 1`
 /// that must be inserted into the database.
 /// 2. a roaring bitmap of all the document ids present in the database
-fn compute_facet_number_levels<'t>(
-    rtxn: &'t heed::RoTxn,
+fn compute_facet_number_levels(
+    rtxn: &'_ heed::RoTxn,
     db: heed::Database<FacetLevelValueF64Codec, CboRoaringBitmapCodec>,
     compression_type: CompressionType,
     compression_level: Option<u32>,
@@ -496,7 +496,7 @@ where
             bitmaps.clear();
         }
         // level 0 is already stored in the DB
-        return Ok(vec![]);
+        Ok(vec![])
     } else {
         // level >= 1
         // we compute each element of this level based on the elements of the level below it
@@ -562,7 +562,7 @@ where
         }
 
         sub_writers.push(writer_into_reader(cur_writer)?);
-        return Ok(sub_writers);
+        Ok(sub_writers)
     }
 }
 
@@ -598,7 +598,7 @@ fn write_number_entry(
 ) -> Result<()> {
     let key = (field_id, level, left, right);
     let key = FacetLevelValueF64Codec::bytes_encode(&key).ok_or(Error::Encoding)?;
-    let data = CboRoaringBitmapCodec::bytes_encode(&ids).ok_or(Error::Encoding)?;
+    let data = CboRoaringBitmapCodec::bytes_encode(ids).ok_or(Error::Encoding)?;
     writer.insert(&key, &data)?;
     Ok(())
 }

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -332,8 +332,8 @@ fn compute_facet_number_levels(
 /// 1. a vector of grenad::Reader. The reader at index `i` corresponds to the elements of level `i + 1`
 /// that must be inserted into the database.
 /// 2. a roaring bitmap of all the document ids present in the database
-fn compute_facet_strings_levels<'t>(
-    rtxn: &'t heed::RoTxn,
+fn compute_facet_strings_levels(
+    rtxn: &heed::RoTxn,
     db: heed::Database<FacetStringLevelZeroCodec, FacetStringLevelZeroValueCodec>,
     compression_type: CompressionType,
     compression_level: Option<u32>,

--- a/milli/src/update/facets.rs
+++ b/milli/src/update/facets.rs
@@ -263,7 +263,7 @@ impl<'t, 'u, 'i> Facets<'t, 'u, 'i> {
 /// that must be inserted into the database.
 /// 2. a roaring bitmap of all the document ids present in the database
 fn compute_facet_number_levels(
-    rtxn: &'_ heed::RoTxn,
+    rtxn: &heed::RoTxn,
     db: heed::Database<FacetLevelValueF64Codec, CboRoaringBitmapCodec>,
     compression_type: CompressionType,
     compression_level: Option<u32>,

--- a/milli/src/update/index_documents/enrich.rs
+++ b/milli/src/update/index_documents/enrich.rs
@@ -140,7 +140,7 @@ fn fetch_or_generate_document_id(
                 }
                 None => Ok(Err(UserError::MissingDocumentId {
                     primary_key: primary_key.to_string(),
-                    document: obkv_to_object(&document, &documents_batch_index)?,
+                    document: obkv_to_object(document, documents_batch_index)?,
                 })),
             }
         }
@@ -156,7 +156,7 @@ fn fetch_or_generate_document_id(
                         if matching_documents_ids.len() >= 2 {
                             return Ok(Err(UserError::TooManyDocumentIds {
                                 primary_key: nested.name().to_string(),
-                                document: obkv_to_object(&document, &documents_batch_index)?,
+                                document: obkv_to_object(document, documents_batch_index)?,
                             }));
                         }
                     }
@@ -170,7 +170,7 @@ fn fetch_or_generate_document_id(
                 },
                 None => Ok(Err(UserError::MissingDocumentId {
                     primary_key: nested.name().to_string(),
-                    document: obkv_to_object(&document, &documents_batch_index)?,
+                    document: obkv_to_object(document, documents_batch_index)?,
                 })),
             }
         }
@@ -313,7 +313,7 @@ pub fn validate_document_id_value(document_id: Value) -> Result<StdResult<String
             None => Ok(Err(UserError::InvalidDocumentId { document_id: Value::String(string) })),
         },
         Value::Number(number) if number.is_i64() => Ok(Ok(number.to_string())),
-        content => Ok(Err(UserError::InvalidDocumentId { document_id: content.clone() })),
+        content => Ok(Err(UserError::InvalidDocumentId { document_id: content })),
     }
 }
 

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -132,7 +132,7 @@ fn json_to_string<'a>(value: &'a Value, buffer: &'a mut String) -> Option<&'a st
     }
 
     if let Value::String(string) = value {
-        Some(&string)
+        Some(string)
     } else if inner(value, buffer) {
         Some(buffer)
     } else {

--- a/milli/src/update/index_documents/extract/extract_fid_docid_facet_values.rs
+++ b/milli/src/update/index_documents/extract/extract_fid_docid_facet_values.rs
@@ -67,7 +67,7 @@ pub fn extract_fid_docid_facet_values<R: io::Read + io::Seek>(
                 facet_exists_docids.entry(field_id).or_default().insert(document);
 
                 // For the other extraction tasks, prefix the key with the field_id and the document_id
-                key_buffer.extend_from_slice(&docid_bytes);
+                key_buffer.extend_from_slice(docid_bytes);
 
                 let value =
                     serde_json::from_slice(field_bytes).map_err(InternalError::SerdeJson)?;
@@ -107,8 +107,8 @@ pub fn extract_fid_docid_facet_values<R: io::Read + io::Seek>(
     let facet_exists_docids_reader = writer_into_reader(facet_exists_docids_writer)?;
 
     Ok((
-        sorter_into_reader(fid_docid_facet_numbers_sorter, indexer.clone())?,
-        sorter_into_reader(fid_docid_facet_strings_sorter, indexer.clone())?,
+        sorter_into_reader(fid_docid_facet_numbers_sorter, indexer)?,
+        sorter_into_reader(fid_docid_facet_strings_sorter, indexer)?,
         facet_exists_docids_reader,
     ))
 }

--- a/milli/src/update/index_documents/extract/mod.rs
+++ b/milli/src/update/index_documents/extract/mod.rs
@@ -150,7 +150,7 @@ pub(crate) fn data_from_obkv_documents(
     spawn_extraction_task::<_, _, Vec<grenad::Reader<File>>>(
         docid_fid_facet_numbers_chunks,
         indexer,
-        lmdb_writer_sx.clone(),
+        lmdb_writer_sx,
         extract_facet_number_docids,
         merge_cbo_roaring_bitmaps,
         TypedChunk::FieldIdFacetNumberDocids,

--- a/milli/src/update/prefix_word_pairs/prefix_word.rs
+++ b/milli/src/update/prefix_word_pairs/prefix_word.rs
@@ -30,9 +30,8 @@ pub fn index_prefix_word_database(
     debug!("Computing and writing the word prefix pair proximity docids into LMDB on disk...");
 
     let common_prefixes: Vec<_> = common_prefix_fst_words
-        .into_iter()
-        .map(|s| s.into_iter())
-        .flatten()
+        .iter()
+        .flat_map(|s| s.iter())
         .map(|s| s.as_str())
         .filter(|s| s.len() <= max_prefix_length)
         .collect();
@@ -73,7 +72,7 @@ pub fn index_prefix_word_database(
 
     // Now we do the same thing with the new prefixes and all word pairs in the DB
     let new_prefixes: Vec<_> = new_prefix_fst_words
-        .into_iter()
+        .iter()
         .map(|s| s.as_str())
         .filter(|s| s.len() <= max_prefix_length)
         .collect();

--- a/milli/src/update/prefix_word_pairs/word_prefix.rs
+++ b/milli/src/update/prefix_word_pairs/word_prefix.rs
@@ -195,9 +195,8 @@ pub fn index_word_prefix_database(
     // Make a prefix trie from the common prefixes that are shorter than self.max_prefix_length
     let prefixes = PrefixTrieNode::from_sorted_prefixes(
         common_prefix_fst_words
-            .into_iter()
-            .map(|s| s.into_iter())
-            .flatten()
+            .iter()
+            .flat_map(|s| s.iter())
             .map(|s| s.as_str())
             .filter(|s| s.len() <= max_prefix_length),
     );
@@ -237,10 +236,7 @@ pub fn index_word_prefix_database(
     // Now we do the same thing with the new prefixes and all word pairs in the DB
 
     let prefixes = PrefixTrieNode::from_sorted_prefixes(
-        new_prefix_fst_words
-            .into_iter()
-            .map(|s| s.as_str())
-            .filter(|s| s.len() <= max_prefix_length),
+        new_prefix_fst_words.iter().map(|s| s.as_str()).filter(|s| s.len() <= max_prefix_length),
     );
 
     if !prefixes.is_empty() {
@@ -366,7 +362,7 @@ fn execute_on_word_pairs_and_prefixes<I>(
                 &mut prefix_buffer,
                 &prefix_search_start,
                 |prefix_buffer| {
-                    batch.insert(&prefix_buffer, data.to_vec());
+                    batch.insert(prefix_buffer, data.to_vec());
                 },
             );
         }
@@ -484,7 +480,7 @@ impl PrefixTrieNode {
     fn set_search_start(&self, word: &[u8], search_start: &mut PrefixTrieNodeSearchStart) -> bool {
         let byte = word[0];
         if self.children[search_start.0].1 == byte {
-            return true;
+            true
         } else {
             match self.children[search_start.0..].binary_search_by_key(&byte, |x| x.1) {
                 Ok(position) => {
@@ -502,7 +498,7 @@ impl PrefixTrieNode {
     fn from_sorted_prefixes<'a>(prefixes: impl Iterator<Item = &'a str>) -> Self {
         let mut node = PrefixTrieNode::default();
         for prefix in prefixes {
-            node.insert_sorted_prefix(prefix.as_bytes().into_iter());
+            node.insert_sorted_prefix(prefix.as_bytes().iter());
         }
         node
     }


### PR DESCRIPTION
This brings us a step closer to enforcing clippy on each build.

# Pull Request

## Related issue
This does not fix any issue outright, but it is a second round of fixes for clippy after https://github.com/meilisearch/milli/pull/665. This should contribute to fixing https://github.com/meilisearch/milli/pull/659.

## What does this PR do?

Satisfies many issues for clippy. The complaints are mostly:

* Passing reference where a variable is already a reference.
* Using clone where a struct already implements `Copy`
* Using `ok_or_else` when it is a closure that returns a value instead of using the closure to call function (hence we use `ok_or`)
* Unambiguous lifetimes don't need names, so we can just use `'_`
* Using `return` when it is not needed as we are on the last expression of a function.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
