### PR TITLE
When both lat and lng invalid 

### DIFF
--- a/milli/src/update/index_documents/enrich.rs
+++ b/milli/src/update/index_documents/enrich.rs
@@ -346,17 +346,18 @@ pub fn validate_geo_from_json(id: &DocumentId, bytes: &[u8]) -> Result<StdResult
         Value::Object(mut object) => match (object.remove("lat"), object.remove("lng")) {
             (Some(lat), Some(lng)) => {
                 match (extract_finite_float_from_value(lat), extract_finite_float_from_value(lng)) {
-                    (Ok(_), Ok(_)) => Ok(Ok(())),
-                    (Err(value), Ok(_)) => Ok(Err(BadLatitude { document_id: debug_id(), value })),
-                    (Ok(_), Err(value)) => Ok(Err(BadLongitude { document_id: debug_id(), value })),
                     (Err(lat), Err(lng)) => {
                         Ok(Err(BadLatitudeAndLongitude { document_id: debug_id(), lat, lng }))
                     }
+                    (Ok(_), Ok(_)) => Ok(Ok(())),
+                    (Err(value), Ok(_)) => Ok(Err(BadLatitude { document_id: debug_id(), value })),
+                    (Ok(_), Err(value)) => Ok(Err(BadLongitude { document_id: debug_id(), value })),
                 }
             }
+            (None, None) => Ok(Err(MissingLatitudeAndLongitude { document_id: debug_id() })),
             (None, Some(_)) => Ok(Err(MissingLatitude { document_id: debug_id() })),
             (Some(_), None) => Ok(Err(MissingLongitude { document_id: debug_id() })),
-            (None, None) => Ok(Err(MissingLatitudeAndLongitude { document_id: debug_id() })),
+
         },
         value => Ok(Err(NotAnObject { document_id: debug_id(), value })),
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes

## What does this PR do?
-  in function "validate_geo_from_json", When both lat and lng invalid, this exception was never reached, as one of the prior 2 conditions would always match first

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Cargo test was also run, and no tests failed

Thank you so much for contributing to Meilisearch!
