### PR TITLE
Handle non-finite floats consistently in filters

### DIFF
--- a/filter-parser/src/error.rs
+++ b/filter-parser/src/error.rs
@@ -65,6 +65,7 @@ pub enum ErrorKind<'a> {
     MalformedValue,
     InOpeningBracket,
     InClosingBracket,
+    NonFiniteFloat,
     InExpectedValue(ExpectedValueKind),
     ReservedKeyword(String),
     MissingClosingDelimiter(char),
@@ -166,6 +167,9 @@ impl<'a> Display for Error<'a> {
             }
             ErrorKind::InClosingBracket => {
                 writeln!(f, "Expected matching `]` after the list of field names given to `IN[`")?
+            }
+            ErrorKind::NonFiniteFloat => {
+                writeln!(f, "Non finite floats are not supported")?
             }
             ErrorKind::InExpectedValue(ExpectedValueKind::ReservedKeyword) => {
                 writeln!(f, "Expected only comma-separated field names inside `IN[..]` but instead found `{escaped_input}`, which is a keyword. To use `{escaped_input}` as a field name or a value, surround it by quotes.")?

--- a/filter-parser/src/lib.rs
+++ b/filter-parser/src/lib.rs
@@ -44,7 +44,6 @@ mod error;
 mod value;
 
 use std::fmt::Debug;
-use std::str::FromStr;
 
 pub use condition::{parse_condition, parse_to, Condition};
 use condition::{parse_exists, parse_not_exists};
@@ -100,12 +99,13 @@ impl<'a> Token<'a> {
         Error::new_from_external(self.span, error)
     }
 
-    pub fn parse<T>(&self) -> Result<T, Error>
-    where
-        T: FromStr,
-        T::Err: std::error::Error,
-    {
-        self.span.parse().map_err(|e| self.as_external_error(e))
+    pub fn parse_finite_float(&self) -> Result<f64, Error> {
+        let value: f64 = self.span.parse().map_err(|e| self.as_external_error(e))?;
+        if value.is_finite() {
+            Ok(value)
+        } else {
+            Err(Error::new_from_kind(self.span, ErrorKind::NonFiniteFloat))
+        }
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Related issue

Related meilisearch/meilisearch#3000

## What does this PR do?

### User

- Filters using `field = inf`, (or `infinite`, `NaN`) now match the value as a string rather than returning an internal error.
- Filters using `field < inf` (or other comparison operators) now return an invalid_filter error rather than returning an internal error, much like when using `field < aaa`.

### Implementation

- Add new `NonFiniteFloat` error variants to the filter-parser errors
- Add `Token::parse_as_finite_float` that can fail both when the string is not a float and when the float is not finite
- Refactor `Filter::inner_evaluate` to always use `parse_as_finite_float` instead of just `parse`
- Add corresponding tests

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
