### PR TITLE
Reduce memory usage of the MatchingWords structure

### DIFF
--- a/benchmarks/benches/formatting.rs
+++ b/benchmarks/benches/formatting.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use criterion::{criterion_group, criterion_main};
 use milli::tokenizer::TokenizerBuilder;
 use milli::{FormatOptions, MatcherBuilder, MatchingWord, MatchingWords};
@@ -18,14 +20,14 @@ fn bench_formatting(c: &mut criterion::Criterion) {
     		name: "'the door d'",
 			text: r#"He used to do the door sounds in "Star Trek" with his mouth, phssst, phssst. The MD-11 passenger and cargo doors also tend to behave like electromagnetic apertures, because the doors do not have continuous electrical contact with the door frames around the door perimeter. But Theodor said that the doors don't work."#,
 			matching_words: MatcherBuilder::new(MatchingWords::new(vec![
-	            (vec![MatchingWord::new("t".to_string(), 0, false), MatchingWord::new("he".to_string(), 0, false)], vec![0]),
-	            (vec![MatchingWord::new("the".to_string(), 0, false)], vec![0]),
-	            (vec![MatchingWord::new("door".to_string(), 1, false)], vec![1]),
-	            (vec![MatchingWord::new("do".to_string(), 0, false), MatchingWord::new("or".to_string(), 0, false)], vec![0]),
-	            (vec![MatchingWord::new("thedoor".to_string(), 1, false)], vec![0, 1]),
-	            (vec![MatchingWord::new("d".to_string(), 0, true)], vec![2]),
-	            (vec![MatchingWord::new("thedoord".to_string(), 1, true)], vec![0, 1, 2]),
-	            (vec![MatchingWord::new("doord".to_string(), 1, true)], vec![1, 2]),
+	            (vec![Rc::new(MatchingWord::new("t".to_string(), 0, false).unwrap()), Rc::new(MatchingWord::new("he".to_string(), 0, false).unwrap())], vec![0]),
+	            (vec![Rc::new(MatchingWord::new("the".to_string(), 0, false).unwrap())], vec![0]),
+	            (vec![Rc::new(MatchingWord::new("door".to_string(), 1, false).unwrap())], vec![1]),
+	            (vec![Rc::new(MatchingWord::new("do".to_string(), 0, false).unwrap()), Rc::new(MatchingWord::new("or".to_string(), 0, false).unwrap())], vec![0]),
+	            (vec![Rc::new(MatchingWord::new("thedoor".to_string(), 1, false).unwrap())], vec![0, 1]),
+	            (vec![Rc::new(MatchingWord::new("d".to_string(), 0, true).unwrap())], vec![2]),
+	            (vec![Rc::new(MatchingWord::new("thedoord".to_string(), 1, true).unwrap())], vec![0, 1, 2]),
+	            (vec![Rc::new(MatchingWord::new("doord".to_string(), 1, true).unwrap())], vec![1, 2]),
         	]
             ), TokenizerBuilder::default().build()),
 		},

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -70,6 +70,21 @@ pub type SmallVec8<T> = smallvec::SmallVec<[T; 8]>;
 /// expressed in term of latitude and longitude.
 pub type GeoPoint = rstar::primitives::GeomWithData<[f64; 3], (DocumentId, [f64; 2])>;
 
+/// The maximum length a LMDB key can be.
+///
+/// Note that the actual allowed length is a little bit higher, but
+/// we keep a margin of safety.
+const MAX_LMDB_KEY_LENGTH: usize = 500;
+
+/// The maximum length a field value can be when inserted in an LMDB key.
+///
+/// This number is determined by the keys of the different facet databases
+/// and adding a margin of safety.
+pub const MAX_FACET_VALUE_LENGTH: usize = MAX_LMDB_KEY_LENGTH - 20;
+
+/// The maximum length a word can be
+pub const MAX_WORD_LENGTH: usize = MAX_LMDB_KEY_LENGTH / 2;
+
 pub const MAX_POSITION_PER_ATTRIBUTE: u32 = u16::MAX as u32 + 1;
 
 // Convert an absolute word position into a relative position.

--- a/milli/src/search/matches/mod.rs
+++ b/milli/src/search/matches/mod.rs
@@ -503,9 +503,9 @@ mod tests {
 
     fn matching_words() -> MatchingWords {
         let all = vec![
-            Rc::new(MatchingWord::new("split".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("the".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("world".to_string(), 1, true)),
+            Rc::new(MatchingWord::new("split".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("the".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("world".to_string(), 1, true).unwrap()),
         ];
         let matching_words = vec![
             (vec![all[0].clone()], vec![0]),
@@ -595,8 +595,8 @@ mod tests {
     #[test]
     fn highlight_unicode() {
         let all = vec![
-            Rc::new(MatchingWord::new("wessfali".to_string(), 1, true)),
-            Rc::new(MatchingWord::new("world".to_string(), 1, true)),
+            Rc::new(MatchingWord::new("wessfali".to_string(), 1, true).unwrap()),
+            Rc::new(MatchingWord::new("world".to_string(), 1, true).unwrap()),
         ];
         let matching_words = vec![(vec![all[0].clone()], vec![0]), (vec![all[1].clone()], vec![1])];
 
@@ -832,12 +832,12 @@ mod tests {
     #[test]
     fn partial_matches() {
         let all = vec![
-            Rc::new(MatchingWord::new("the".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("t".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("he".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("door".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("do".to_string(), 0, false)),
-            Rc::new(MatchingWord::new("or".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("the".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("t".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("he".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("door".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("do".to_string(), 0, false).unwrap()),
+            Rc::new(MatchingWord::new("or".to_string(), 0, false).unwrap()),
         ];
         let matching_words = vec![
             (vec![all[0].clone()], vec![0]),

--- a/milli/src/search/matches/mod.rs
+++ b/milli/src/search/matches/mod.rs
@@ -494,16 +494,23 @@ impl<'t, A: AsRef<[u8]>> Matcher<'t, '_, A> {
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use charabia::TokenizerBuilder;
 
     use super::*;
     use crate::search::matches::matching_words::MatchingWord;
 
     fn matching_words() -> MatchingWords {
+        let all = vec![
+            Rc::new(MatchingWord::new("split".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("the".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("world".to_string(), 1, true)),
+        ];
         let matching_words = vec![
-            (vec![MatchingWord::new("split".to_string(), 0, false)], vec![0]),
-            (vec![MatchingWord::new("the".to_string(), 0, false)], vec![1]),
-            (vec![MatchingWord::new("world".to_string(), 1, true)], vec![2]),
+            (vec![all[0].clone()], vec![0]),
+            (vec![all[1].clone()], vec![1]),
+            (vec![all[2].clone()], vec![2]),
         ];
 
         MatchingWords::new(matching_words)
@@ -587,10 +594,11 @@ mod tests {
 
     #[test]
     fn highlight_unicode() {
-        let matching_words = vec![
-            (vec![MatchingWord::new("wessfali".to_string(), 1, true)], vec![0]),
-            (vec![MatchingWord::new("world".to_string(), 1, true)], vec![1]),
+        let all = vec![
+            Rc::new(MatchingWord::new("wessfali".to_string(), 1, true)),
+            Rc::new(MatchingWord::new("world".to_string(), 1, true)),
         ];
+        let matching_words = vec![(vec![all[0].clone()], vec![0]), (vec![all[1].clone()], vec![1])];
 
         let matching_words = MatchingWords::new(matching_words);
 
@@ -823,24 +831,20 @@ mod tests {
 
     #[test]
     fn partial_matches() {
+        let all = vec![
+            Rc::new(MatchingWord::new("the".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("t".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("he".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("door".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("do".to_string(), 0, false)),
+            Rc::new(MatchingWord::new("or".to_string(), 0, false)),
+        ];
         let matching_words = vec![
-            (vec![MatchingWord::new("the".to_string(), 0, false)], vec![0]),
-            (
-                vec![
-                    MatchingWord::new("t".to_string(), 0, false),
-                    MatchingWord::new("he".to_string(), 0, false),
-                ],
-                vec![0],
-            ),
-            (vec![MatchingWord::new("door".to_string(), 0, false)], vec![1]),
-            (
-                vec![
-                    MatchingWord::new("do".to_string(), 0, false),
-                    MatchingWord::new("or".to_string(), 0, false),
-                ],
-                vec![1],
-            ),
-            (vec![MatchingWord::new("do".to_string(), 0, false)], vec![2]),
+            (vec![all[0].clone()], vec![0]),
+            (vec![all[1].clone(), all[2].clone()], vec![0]),
+            (vec![all[3].clone()], vec![1]),
+            (vec![all[4].clone(), all[5].clone()], vec![1]),
+            (vec![all[4].clone()], vec![2]),
         ];
 
         let matching_words = MatchingWords::new(matching_words);

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -1395,14 +1395,14 @@ mod test {
     }
     unsafe impl GlobalAlloc for CountingAlloc {
         unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
-            self.allocated.fetch_add(layout.size() as i64, atomic::Ordering::SeqCst);
-            self.resident.fetch_add(layout.size() as i64, atomic::Ordering::SeqCst);
+            self.allocated.fetch_add(layout.size() as i64, atomic::Ordering::Relaxed);
+            self.resident.fetch_add(layout.size() as i64, atomic::Ordering::Relaxed);
 
             System.alloc(layout)
         }
 
         unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
-            self.resident.fetch_sub(layout.size() as i64, atomic::Ordering::SeqCst);
+            self.resident.fetch_sub(layout.size() as i64, atomic::Ordering::Relaxed);
             System.dealloc(ptr, layout)
         }
     }

--- a/milli/src/search/query_tree.rs
+++ b/milli/src/search/query_tree.rs
@@ -693,11 +693,13 @@ fn create_matching_words(
 
                             if let Some(synonyms) = ctx.synonyms(&words)? {
                                 for synonym in synonyms {
-                                    let synonym = synonym
+                                    if let Some(synonym) = synonym
                                         .into_iter()
-                                        .flat_map(|syn| matching_word_cache.insert(syn, 0, false))
-                                        .collect();
-                                    matching_words.push((synonym, ids.clone()));
+                                        .map(|syn| matching_word_cache.insert(syn, 0, false))
+                                        .collect()
+                                    {
+                                        matching_words.push((synonym, ids.clone()));
+                                    }
                                 }
                             }
                             let word = words.concat();

--- a/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
+++ b/milli/src/update/index_documents/extract/extract_docid_word_positions.rs
@@ -7,11 +7,11 @@ use charabia::{SeparatorKind, Token, TokenKind, TokenizerBuilder};
 use roaring::RoaringBitmap;
 use serde_json::Value;
 
-use super::helpers::{
-    concat_u32s_array, create_sorter, sorter_into_reader, GrenadParameters, MAX_WORD_LENGTH,
-};
+use super::helpers::{concat_u32s_array, create_sorter, sorter_into_reader, GrenadParameters};
 use crate::error::{InternalError, SerializationError};
-use crate::{absolute_from_relative_position, FieldId, Result, MAX_POSITION_PER_ATTRIBUTE};
+use crate::{
+    absolute_from_relative_position, FieldId, Result, MAX_POSITION_PER_ATTRIBUTE, MAX_WORD_LENGTH,
+};
 
 /// Extracts the word and positions where this word appear and
 /// prefixes it by the document id.

--- a/milli/src/update/index_documents/extract/extract_facet_string_docids.rs
+++ b/milli/src/update/index_documents/extract/extract_facet_string_docids.rs
@@ -6,9 +6,8 @@ use heed::BytesEncode;
 use super::helpers::{create_sorter, sorter_into_reader, try_split_array_at, GrenadParameters};
 use crate::heed_codec::facet::{FacetGroupKey, FacetGroupKeyCodec};
 use crate::heed_codec::StrRefCodec;
-use crate::update::index_documents::helpers::MAX_FACET_VALUE_LENGTH;
 use crate::update::index_documents::merge_cbo_roaring_bitmaps;
-use crate::{FieldId, Result};
+use crate::{FieldId, Result, MAX_FACET_VALUE_LENGTH};
 
 /// Extracts the facet string and the documents ids where this facet string appear.
 ///

--- a/milli/src/update/index_documents/extract/extract_fid_docid_facet_values.rs
+++ b/milli/src/update/index_documents/extract/extract_fid_docid_facet_values.rs
@@ -12,9 +12,8 @@ use serde_json::Value;
 use super::helpers::{create_sorter, keep_first, sorter_into_reader, GrenadParameters};
 use crate::error::InternalError;
 use crate::facet::value_encoding::f64_into_bytes;
-use crate::update::index_documents::helpers::MAX_FACET_VALUE_LENGTH;
 use crate::update::index_documents::{create_writer, writer_into_reader};
-use crate::{CboRoaringBitmapCodec, DocumentId, FieldId, Result, BEU32};
+use crate::{CboRoaringBitmapCodec, DocumentId, FieldId, Result, BEU32, MAX_FACET_VALUE_LENGTH};
 
 /// Extracts the facet values of each faceted field of each document.
 ///

--- a/milli/src/update/index_documents/helpers/mod.rs
+++ b/milli/src/update/index_documents/helpers/mod.rs
@@ -18,20 +18,7 @@ pub use merge_functions::{
     serialize_roaring_bitmap, MergeFn,
 };
 
-/// The maximum length a LMDB key can be.
-///
-/// Note that the actual allowed length is a little bit higher, but
-/// we keep a margin of safety.
-const MAX_LMDB_KEY_LENGTH: usize = 500;
-
-/// The maximum length a field value can be when inserted in an LMDB key.
-///
-/// This number is determined by the keys of the different facet databases
-/// and adding a margin of safety.
-pub const MAX_FACET_VALUE_LENGTH: usize = MAX_LMDB_KEY_LENGTH - 20;
-
-/// The maximum length a word can be
-pub const MAX_WORD_LENGTH: usize = MAX_LMDB_KEY_LENGTH / 2;
+use crate::MAX_WORD_LENGTH;
 
 pub fn valid_lmdb_key(key: impl AsRef<[u8]>) -> bool {
     key.as_ref().len() <= MAX_WORD_LENGTH * 2 && !key.as_ref().is_empty()


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes (partially) https://github.com/meilisearch/meilisearch/issues/3115 

## What does this PR do?
1. Reduces the memory usage caused by the creation of a 10-word query tree by 20x. 
   This is done by deduplicating the `MatchingWord` values, which are heavy because of their inner DFA. The deduplication works by wrapping each `MatchingWord` in a reference-counted box and using a hash map to determine whether a  `MatchingWord` DFA already exists for a certain signature, or whether a new one needs to be built.
 
2. Avoid the worst-case scenario of creating a `MatchingWord` for extremely long words that cannot be indexed by milli.