### PR TITLE
Add `milli::filter_parser` & `From<&str>` implementation for `Token`

### DIFF
--- a/filter-parser/src/lib.rs
+++ b/filter-parser/src/lib.rs
@@ -115,6 +115,13 @@ impl<'a> From<Span<'a>> for Token<'a> {
     }
 }
 
+/// Allow [Token] to be constructed from &[str]
+impl<'a> From<&'a str> for Token<'a> {
+    fn from(s: &'a str) -> Self {
+        Token::from(Span::new_extra(s, s))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FilterCondition<'a> {
     Not(Box<Self>),
@@ -663,6 +670,13 @@ pub mod tests {
         let filter = FilterCondition::parse("account_ids=1 OR account_ids=2 AND account_ids=3 OR account_ids=4 AND account_ids=5 OR account_ids=6").unwrap().unwrap();
         assert!(filter.token_at_depth(2).is_some());
         assert!(filter.token_at_depth(3).is_none());
+    }
+
+    #[test]
+    fn token_from_str() {
+        let s = "test string that should not be parsed";
+        let token: Token = s.into();
+        assert_eq!(token.value(), s);
     }
 }
 

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -22,7 +22,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 use std::hash::BuildHasherDefault;
 
-pub use filter_parser::{Condition, FilterCondition};
+pub use filter_parser::{Condition, FilterCondition, Span, Token};
 use fxhash::{FxHasher32, FxHasher64};
 pub use grenad::CompressionType;
 use serde_json::Value;


### PR DESCRIPTION
## What does this PR do?
The current `milli::Filter` and `milli::FilterCondition` APIs require working with some members of `filter_parser` directly that `milli::` does *not* re-export to its users. Also, using `filter_parser` does not make sense when using milli from an embedded context where there is no query to parse.

Instead of reworking `milli::Filter` and `milli::FilterCondition`, this PR adds two non-breaking changes that ease the use of milli:
- Re-exports the dependent version of `filter_parser` in `milli`, just like `milli::heed`
- Implements `From<&str>` for `filter_parser::Token`
  - This will also allow some basic tests that need to create a `Token` from a string to avoid some boilerplate.

In conjunction, both of these will allow milli users to easily create a `Token` from a `&str` without needing to add `filter_parser` as an extra dependency.

Note: I wanted to use `FromStr` for the `From` implementation; however, it requires returning a `Result` which is not needed for the conversion. Thus, I just left it as `From<&str>`.