### PR TITLE
Geosearch for zero radius

### DIFF
--- a/milli/src/search/facet/filter.rs
+++ b/milli/src/search/facet/filter.rs
@@ -632,7 +632,6 @@ mod tests {
 
         index
             .update_settings(|settings| {
-                settings.set_searchable_fields(vec![S("_geo")]);
                 settings.set_filterable_fields(hashset! { S("_geo") });
             })
             .unwrap();


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3167 (https://github.com/meilisearch/meilisearch/issues/3167)

## What does this PR do?
- allows Geosearch with zero radius to return the specified location when the coordinates match perfectly (instead of returning nothing). See link for more details.
- new attempt on https://github.com/meilisearch/milli/pull/713

## PR checklist
Please check if your PR fulfills the following requirements:
- [ X ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ X ] Have you read the contributing guidelines?
- [ X ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
