### PR TITLE
Fix distincted exhaustive hits

### DIFF
--- a/milli/src/search/criteria/initial.rs
+++ b/milli/src/search/criteria/initial.rs
@@ -1,7 +1,7 @@
 use roaring::RoaringBitmap;
 
 use super::{Criterion, CriterionParameters, CriterionResult};
-use crate::search::criteria::{resolve_query_tree, Context};
+use crate::search::criteria::{resolve_query_tree, Context, InitialCandidates};
 use crate::search::query_tree::Operation;
 use crate::search::Distinct;
 use crate::Result;
@@ -27,7 +27,7 @@ impl<'t, D> Initial<'t, D> {
             query_tree,
             candidates: None,
             filtered_candidates,
-            bucket_candidates: None,
+            initial_candidates: None,
         };
         Initial { ctx, answer: Some(answer), exhaustive_number_hits, distinct }
     }
@@ -41,32 +41,34 @@ impl<D: Distinct> Criterion for Initial<'_, D> {
             .map(|mut answer| {
                 if self.exhaustive_number_hits && answer.query_tree.is_some() {
                     // resolve the whole query tree to retrieve an exhaustive list of documents matching the query.
+                    // then remove the potential soft deleted documents.
                     let mut candidates = resolve_query_tree(
                         self.ctx,
                         answer.query_tree.as_ref().unwrap(),
                         params.wdcache,
-                    )?;
+                    )? - params.excluded_candidates;
 
                     // Apply the filters on the documents retrieved with the query tree.
                     if let Some(ref filtered_candidates) = answer.filtered_candidates {
                         candidates &= filtered_candidates;
                     }
 
-                    // because the bucket_candidates should be an exhaustive count of the matching documents,
+                    // because the initial_candidates should be an exhaustive count of the matching documents,
                     // we precompute the distinct attributes.
-                    let bucket_candidates = match &mut self.distinct {
+                    let initial_candidates = match &mut self.distinct {
                         Some(distinct) => {
-                            let mut bucket_candidates = RoaringBitmap::new();
+                            let mut initial_candidates = RoaringBitmap::new();
                             for c in distinct.distinct(candidates.clone(), RoaringBitmap::new()) {
-                                bucket_candidates.insert(c?);
+                                initial_candidates.insert(c?);
                             }
-                            bucket_candidates
+                            initial_candidates
                         }
                         None => candidates.clone(),
                     };
 
                     answer.candidates = Some(candidates);
-                    answer.bucket_candidates = Some(bucket_candidates);
+                    answer.initial_candidates =
+                        Some(InitialCandidates::Exhaustive(initial_candidates));
                 }
                 Ok(answer)
             })

--- a/milli/tests/search/distinct.rs
+++ b/milli/tests/search/distinct.rs
@@ -8,7 +8,7 @@ use Criterion::*;
 use crate::search::{self, EXTERNAL_DOCUMENTS_IDS};
 
 macro_rules! test_distinct {
-    ($func:ident, $distinct:ident, $criteria:expr, $n_res:expr) => {
+    ($func:ident, $distinct:ident, $exhaustive:ident, $limit:expr, $criteria:expr, $n_res:expr) => {
         #[test]
         fn $func() {
             let criteria = $criteria;
@@ -26,7 +26,8 @@ macro_rules! test_distinct {
 
             let mut search = Search::new(&rtxn, &index);
             search.query(search::TEST_QUERY);
-            search.limit(EXTERNAL_DOCUMENTS_IDS.len());
+            search.limit($limit);
+            search.exhaustive_number_hits($exhaustive);
             search.authorize_typos(true);
             search.terms_matching_strategy(TermsMatchingStrategy::default());
 
@@ -46,6 +47,7 @@ macro_rules! test_distinct {
                             Some(d.id)
                         }
                     })
+                    .take($limit)
                     .collect();
 
             let documents_ids = search::internal_to_external_ids(&index, &documents_ids);
@@ -55,24 +57,115 @@ macro_rules! test_distinct {
 }
 
 test_distinct!(
+    exhaustive_distinct_string_default_criteria,
+    tag,
+    true,
+    1,
+    vec![Words, Typo, Proximity, Attribute, Exactness],
+    3
+);
+test_distinct!(
+    exhaustive_distinct_number_default_criteria,
+    asc_desc_rank,
+    true,
+    1,
+    vec![Words, Typo, Proximity, Attribute, Exactness],
+    7
+);
+
+test_distinct!(
     distinct_string_default_criteria,
     tag,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
     vec![Words, Typo, Proximity, Attribute, Exactness],
     3
 );
 test_distinct!(
     distinct_number_default_criteria,
     asc_desc_rank,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
     vec![Words, Typo, Proximity, Attribute, Exactness],
     7
 );
-test_distinct!(distinct_string_criterion_words, tag, vec![Words], 3);
-test_distinct!(distinct_number_criterion_words, asc_desc_rank, vec![Words], 7);
-test_distinct!(distinct_string_criterion_words_typo, tag, vec![Words, Typo], 3);
-test_distinct!(distinct_number_criterion_words_typo, asc_desc_rank, vec![Words, Typo], 7);
-test_distinct!(distinct_string_criterion_words_proximity, tag, vec![Words, Proximity], 3);
-test_distinct!(distinct_number_criterion_words_proximity, asc_desc_rank, vec![Words, Proximity], 7);
-test_distinct!(distinct_string_criterion_words_attribute, tag, vec![Words, Attribute], 3);
-test_distinct!(distinct_number_criterion_words_attribute, asc_desc_rank, vec![Words, Attribute], 7);
-test_distinct!(distinct_string_criterion_words_exactness, tag, vec![Words, Exactness], 3);
-test_distinct!(distinct_number_criterion_words_exactness, asc_desc_rank, vec![Words, Exactness], 7);
+test_distinct!(
+    distinct_string_criterion_words,
+    tag,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words],
+    3
+);
+test_distinct!(
+    distinct_number_criterion_words,
+    asc_desc_rank,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words],
+    7
+);
+test_distinct!(
+    distinct_string_criterion_words_typo,
+    tag,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Typo],
+    3
+);
+test_distinct!(
+    distinct_number_criterion_words_typo,
+    asc_desc_rank,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Typo],
+    7
+);
+test_distinct!(
+    distinct_string_criterion_words_proximity,
+    tag,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Proximity],
+    3
+);
+test_distinct!(
+    distinct_number_criterion_words_proximity,
+    asc_desc_rank,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Proximity],
+    7
+);
+test_distinct!(
+    distinct_string_criterion_words_attribute,
+    tag,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Attribute],
+    3
+);
+test_distinct!(
+    distinct_number_criterion_words_attribute,
+    asc_desc_rank,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Attribute],
+    7
+);
+test_distinct!(
+    distinct_string_criterion_words_exactness,
+    tag,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Exactness],
+    3
+);
+test_distinct!(
+    distinct_number_criterion_words_exactness,
+    asc_desc_rank,
+    false,
+    EXTERNAL_DOCUMENTS_IDS.len(),
+    vec![Words, Exactness],
+    7
+);


### PR DESCRIPTION
This PR changes the name and behavior of `bucket_candidates`:
- `bucket_candidates` become `initial_candidates` that is less confusing
- `initial_candidates` is no more a simple `RoaringBitmap` but an enum allowing us to precise if the candidates are exhaustive or not
- this enum ensures that any modification is allowed only if the candidates are not already exhaustive.

The bug occurred because `initial_candidates` are modified during the bucket sort allowing the estimation to be more and more precise along the search, and this was an issue when the `initial_candidates` were already exhaustive, now, if candidates are exhaustive, then no modifications are made.