### PR TITLE
Fix typo initial candidates computation

### DIFF
--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -143,8 +143,8 @@ impl<'t> Criterion for Typo<'t> {
                     }) => {
                         self.initial_candidates =
                             match (self.initial_candidates.take(), initial_candidates) {
-                                (Some(self_bc), Some(parent_bc)) => Some(self_bc | parent_bc),
-                                (self_bc, parent_bc) => self_bc.or(parent_bc),
+                                (Some(self_ic), Some(parent_ic)) => Some(self_ic | parent_ic),
+                                (self_ic, parent_ic) => self_ic.or(parent_ic),
                             };
 
                         let candidates = match candidates.or(filtered_candidates) {

--- a/milli/src/search/criteria/typo.rs
+++ b/milli/src/search/criteria/typo.rs
@@ -141,7 +141,12 @@ impl<'t> Criterion for Typo<'t> {
                         filtered_candidates,
                         initial_candidates,
                     }) => {
-                        self.initial_candidates = initial_candidates;
+                        self.initial_candidates =
+                            match (self.initial_candidates.take(), initial_candidates) {
+                                (Some(self_bc), Some(parent_bc)) => Some(self_bc | parent_bc),
+                                (self_bc, parent_bc) => self_bc.or(parent_bc),
+                            };
+
                         let candidates = match candidates.or(filtered_candidates) {
                             Some(candidates) => {
                                 Candidates::Allowed(candidates - params.excluded_candidates)

--- a/milli/src/search/criteria/words.rs
+++ b/milli/src/search/criteria/words.rs
@@ -74,8 +74,8 @@ impl<'t> Criterion for Words<'t> {
 
                         self.initial_candidates =
                             match (self.initial_candidates.take(), initial_candidates) {
-                                (Some(self_bc), Some(parent_bc)) => Some(self_bc | parent_bc),
-                                (self_bc, parent_bc) => self_bc.or(parent_bc),
+                                (Some(self_ic), Some(parent_ic)) => Some(self_ic | parent_ic),
+                                (self_ic, parent_ic) => self_ic.or(parent_ic),
                             };
                     }
                     Some(CriterionResult {


### PR DESCRIPTION
When `Typo` criterion was after a different criterion than `Words` and the previous criterion wasn't returning any candidates at the first iteration of the bucket sort, then the `initial_candidates` were lost.

Now, `Typo`ensure to keep the `initial_candidates` between iterations.


related to https://github.com/meilisearch/meilisearch/issues/3200#issuecomment-1345179578
related to https://github.com/meilisearch/meilisearch/issues/3228