### PR TITLE
Fix two nightly errors

### DIFF
--- a/filter-parser/src/error.rs
+++ b/filter-parser/src/error.rs
@@ -33,7 +33,7 @@ impl<E> NomErrorExt<E> for nom::Err<E> {
 
 /// cut a parser and map the error
 pub fn cut_with_err<'a, O>(
-    mut parser: impl FnMut(Span<'a>) -> IResult<O>,
+    mut parser: impl FnMut(Span<'a>) -> IResult<'a, O>,
     mut with: impl FnMut(Error<'a>) -> Error<'a>,
 ) -> impl FnMut(Span<'a>) -> IResult<O> {
     move |input| match parser.parse(input) {

--- a/filter-parser/src/lib.rs
+++ b/filter-parser/src/lib.rs
@@ -170,7 +170,9 @@ impl<'a> FilterCondition<'a> {
 }
 
 /// remove OPTIONAL whitespaces before AND after the provided parser.
-fn ws<'a, O>(inner: impl FnMut(Span<'a>) -> IResult<O>) -> impl FnMut(Span<'a>) -> IResult<O> {
+fn ws<'a, O>(
+    inner: impl FnMut(Span<'a>) -> IResult<'a, O>,
+) -> impl FnMut(Span<'a>) -> IResult<'a, O> {
     delimited(multispace0, inner, multispace0)
 }
 


### PR DESCRIPTION
Currently, we have these two errors on rust nightly. It would be nice to help rustc understand what's going on

```
error[E0658]: anonymous lifetimes in `impl Trait` are unstable
   --> filter-parser/src/lib.rs:173:53
    |
173 | fn ws<'a, O>(inner: impl FnMut(Span<'a>) -> IResult<O>) -> impl FnMut(Span<'a>) -> IResult<O> {
    |                                                     ^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
help: consider introducing a named lifetime parameter
    |
173 | fn ws<'a, 'a, O>(inner: impl FnMut(Span<'a>) -> IResult<'a, O>) -> impl FnMut(Span<'a>) -> IResult<O> {
    |       +++                                               +++

error[E0658]: anonymous lifetimes in `impl Trait` are unstable
  --> filter-parser/src/error.rs:36:49
   |
36 |     mut parser: impl FnMut(Span<'a>) -> IResult<O>,
   |                                                 ^ expected named lifetime parameter
   |
   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
help: consider introducing a named lifetime parameter
   |
35 ~ pub fn cut_with_err<'a, 'a, O>(
36 ~     mut parser: impl FnMut(Span<'a>) -> IResult<'a, O>,
   |

For more information about this error, try `rustc --explain E0658`.
error: could not compile `filter-parser` due to 2 previous errors
```