### PR TITLE
Add a "Criterion implementation strategy" parameter to Search

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt::Display;
 use std::fs::File;
 use std::io::{stdin, BufRead, BufReader, Cursor, Read, Write};
 use std::path::PathBuf;
@@ -349,6 +350,29 @@ fn documents_from_csv(reader: impl Read) -> Result<Vec<u8>> {
     documents.into_inner().map_err(Into::into)
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SearchStrategyOption(CriterionImplementationStrategy);
+impl FromStr for SearchStrategyOption {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "dynamic" => Ok(SearchStrategyOption(CriterionImplementationStrategy::Dynamic)),
+            "set" => Ok(SearchStrategyOption(CriterionImplementationStrategy::OnlySetBased)),
+            "iterative" => Ok(SearchStrategyOption(CriterionImplementationStrategy::OnlyIterative)),
+            _ => Err("could not parse {s} as a criterion implementation strategy, available options are `dynamic`, `set`, and `iterative`".to_owned()),
+        }
+    }
+}
+impl Display for SearchStrategyOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            CriterionImplementationStrategy::OnlyIterative => Display::fmt("iterative", f),
+            CriterionImplementationStrategy::OnlySetBased => Display::fmt("set", f),
+            CriterionImplementationStrategy::Dynamic => Display::fmt("dynamic", f),
+        }
+    }
+}
+
 #[derive(Debug, StructOpt)]
 struct Search {
     query: Option<String>,
@@ -360,6 +384,8 @@ struct Search {
     limit: Option<usize>,
     #[structopt(short, long, conflicts_with = "query")]
     interactive: bool,
+    #[structopt(short, long)]
+    strategy: Option<SearchStrategyOption>,
 }
 
 impl Performer for Search {
@@ -379,6 +405,7 @@ impl Performer for Search {
                             &self.filter,
                             &self.offset,
                             &self.limit,
+                            &self.strategy,
                         )?;
 
                         let time = now.elapsed();
@@ -386,6 +413,7 @@ impl Performer for Search {
                         let hits = serde_json::to_string_pretty(&jsons)?;
 
                         println!("{}", hits);
+
                         eprintln!("found {} results in {:.02?}", jsons.len(), time);
                     }
                     _ => break,
@@ -399,6 +427,7 @@ impl Performer for Search {
                 &self.filter,
                 &self.offset,
                 &self.limit,
+                &self.strategy,
             )?;
 
             let time = now.elapsed();
@@ -420,6 +449,7 @@ impl Search {
         filter: &Option<String>,
         offset: &Option<usize>,
         limit: &Option<usize>,
+        strategy: &Option<SearchStrategyOption>,
     ) -> Result<Vec<Object>> {
         let txn = index.read_txn()?;
         let mut search = index.search(&txn);
@@ -441,7 +471,10 @@ impl Search {
         if let Some(limit) = limit {
             search.limit(*limit);
         }
-        search.criterion_implementation_strategy(CriterionImplementationStrategy::OnlyIterative);
+        if let Some(strategy) = strategy {
+            search.criterion_implementation_strategy(strategy.0);
+        }
+
         let result = search.execute()?;
 
         let fields_ids_map = index.fields_ids_map(&txn)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,7 +13,7 @@ use milli::update::UpdateIndexingStep::{
     ComputeIdsAndMergeDocuments, IndexDocuments, MergeDataIntoFinalDatabase, RemapDocumentAddition,
 };
 use milli::update::{self, IndexDocumentsConfig, IndexDocumentsMethod, IndexerConfig};
-use milli::{heed, Index, Object};
+use milli::{heed, CriterionImplementationStrategy, Index, Object};
 use structopt::StructOpt;
 
 #[global_allocator]
@@ -441,7 +441,7 @@ impl Search {
         if let Some(limit) = limit {
             search.limit(*limit);
         }
-
+        search.criterion_implementation_strategy(CriterionImplementationStrategy::OnlyIterative);
         let result = search.execute()?;
 
         let fields_ids_map = index.fields_ids_map(&txn)?;

--- a/milli/src/lib.rs
+++ b/milli/src/lib.rs
@@ -42,8 +42,9 @@ pub use self::heed_codec::{
 };
 pub use self::index::Index;
 pub use self::search::{
-    FacetDistribution, Filter, FormatOptions, MatchBounds, MatcherBuilder, MatchingWord,
-    MatchingWords, Search, SearchResult, TermsMatchingStrategy, DEFAULT_VALUES_PER_FACET,
+    CriterionImplementationStrategy, FacetDistribution, Filter, FormatOptions, MatchBounds,
+    MatcherBuilder, MatchingWord, MatchingWords, Search, SearchResult, TermsMatchingStrategy,
+    DEFAULT_VALUES_PER_FACET,
 };
 
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -14,6 +14,7 @@ use self::r#final::Final;
 use self::typo::Typo;
 use self::words::Words;
 use super::query_tree::{Operation, PrimitiveQueryPart, Query, QueryKind};
+use super::CriterionImplementationStrategy;
 use crate::search::criteria::geo::Geo;
 use crate::search::{word_derivations, Distinct, WordDerivationsCache};
 use crate::{AscDesc as AscDescName, DocumentId, FieldId, Index, Member, Result};
@@ -377,6 +378,7 @@ impl<'t> CriteriaBuilder<'t> {
         sort_criteria: Option<Vec<AscDescName>>,
         exhaustive_number_hits: bool,
         distinct: Option<D>,
+        implementation_strategy: CriterionImplementationStrategy,
     ) -> Result<Final<'t>> {
         use crate::criterion::Criterion as Name;
 
@@ -402,12 +404,14 @@ impl<'t> CriteriaBuilder<'t> {
                                     self.rtxn,
                                     criterion,
                                     field.to_string(),
+                                    implementation_strategy,
                                 )?),
                                 AscDescName::Desc(Member::Field(field)) => Box::new(AscDesc::desc(
                                     self.index,
                                     self.rtxn,
                                     criterion,
                                     field.to_string(),
+                                    implementation_strategy,
                                 )?),
                                 AscDescName::Asc(Member::Geo(point)) => {
                                     Box::new(Geo::asc(self.index, self.rtxn, criterion, *point)?)
@@ -421,15 +425,27 @@ impl<'t> CriteriaBuilder<'t> {
                     }
                     None => criterion,
                 },
-                Name::Proximity => Box::new(Proximity::new(self, criterion)),
-                Name::Attribute => Box::new(Attribute::new(self, criterion)),
+                Name::Proximity => {
+                    Box::new(Proximity::new(self, criterion, implementation_strategy))
+                }
+                Name::Attribute => {
+                    Box::new(Attribute::new(self, criterion, implementation_strategy))
+                }
                 Name::Exactness => Box::new(Exactness::new(self, criterion, &primitive_query)?),
-                Name::Asc(field) => {
-                    Box::new(AscDesc::asc(self.index, self.rtxn, criterion, field)?)
-                }
-                Name::Desc(field) => {
-                    Box::new(AscDesc::desc(self.index, self.rtxn, criterion, field)?)
-                }
+                Name::Asc(field) => Box::new(AscDesc::asc(
+                    self.index,
+                    self.rtxn,
+                    criterion,
+                    field,
+                    implementation_strategy,
+                )?),
+                Name::Desc(field) => Box::new(AscDesc::desc(
+                    self.index,
+                    self.rtxn,
+                    criterion,
+                    field,
+                    implementation_strategy,
+                )?),
             };
         }
 

--- a/milli/src/search/criteria/mod.rs
+++ b/milli/src/search/criteria/mod.rs
@@ -370,6 +370,7 @@ impl<'t> CriteriaBuilder<'t> {
         Ok(Self { rtxn, index, words_fst, words_prefixes_fst })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn build<D: 't + Distinct>(
         &'t self,
         query_tree: Option<Operation>,


### PR DESCRIPTION
Add a parameter to search requests which determines the implementation strategy of the criteria. This can be either `set-based`, `iterative`, or `dynamic` (ie choosing between set-based or iterative at search time). See https://github.com/meilisearch/milli/issues/755 for more context about this change.
