### PR TITLE
fix: add POSIX semaphore feature

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -18,7 +18,7 @@ fst = "0.4.7"
 fxhash = "0.2.1"
 geoutils = "0.5.1"
 grenad = { version = "0.4.3", default-features = false, features = ["tempfile"] }
-heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.4", default-features = false, features = ["lmdb", "sync-read-txn"] }
+heed = { git = "https://github.com/meilisearch/heed", tag = "v0.12.5", default-features = false, features = ["lmdb", "sync-read-txn"] }
 json-depth-checker = { path = "../json-depth-checker" }
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
 memmap2 = "0.5.7"
@@ -61,6 +61,10 @@ fuzzcheck = "0.12.1"
 
 [features]
 default = [ "charabia/default" ]
+
+# Use POSIX semaphores instead of SysV semaphores in LMDB
+# For more information on this feature, see heed's Cargo.toml
+lmdb-posix-sem = ["heed/posix-sem"]
 
 # allow chinese specialized tokenization
 chinese = ["charabia/chinese"]


### PR DESCRIPTION
Hi! Please take a look at [this PR](https://github.com/meilisearch/heed/pull/140) first. It will need to be merged before this PR can be merged.

In summary, this PR adds support for running milli on iOS and macOS when using App Sandbox, which is required when submitting to the App Store (and required for all iOS apps; macOS apps can get away without needing the App Sandbox but it's recommended).

Under the hood, this is done by adding a cargo feature to use LMDB's POSIX semaphores instead of SysV semaphores (which is LMDB's default). POSIX semaphores comply with Apple's App Sandbox and actually *might* bring slight performance improvements on *nix platforms.