### PR TITLE
Add Index::map_size

### DIFF
--- a/milli/src/index.rs
+++ b/milli/src/index.rs
@@ -255,6 +255,16 @@ impl Index {
         Ok(self.env.real_disk_size()?)
     }
 
+    /// Returns the map size the underlying environment was opened with, in bytes.
+    ///
+    /// This value does not represent the current on-disk size of the index.
+    ///
+    /// This value is the maximum between the map size passed during the opening of the index
+    /// and the on-disk size of the index at the time of opening.
+    pub fn map_size(&self) -> Result<usize> {
+        Ok(self.env.map_size()?)
+    }
+
     pub fn copy_to_path<P: AsRef<Path>>(&self, path: P, option: CompactionOption) -> Result<File> {
         self.env.copy_to_path(path, option).map_err(Into::into)
     }


### PR DESCRIPTION
# Pull Request

## Related issue
Related to discussion: https://github.com/meilisearch/meilisearch/discussions/3280

## What does this PR do?
- Expose `heed::Env::map_size` through `Index::map_size`. This allows knowing after the fact with which `map_size` an environment was opened (which is not always the `map_size` that was configured for the opening of the environment, see the documentation for `Index::map_size`), which will be necessary to guarantee we can reopen the index with a larger `map_size`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
