### PR TITLE
Update deserr to latest version

### DIFF
--- a/milli/Cargo.toml
+++ b/milli/Cargo.toml
@@ -12,7 +12,7 @@ byteorder = "1.4.3"
 charabia = { version = "0.7.0", default-features = false }
 concat-arrays = "0.1.2"
 crossbeam-channel = "0.5.6"
-deserr = "0.1.4"
+deserr = "0.1.5"
 either = "1.8.0"
 flatten-serde-json = { path = "../flatten-serde-json" }
 fst = "0.4.7"

--- a/milli/src/update/settings.rs
+++ b/milli/src/update/settings.rs
@@ -37,9 +37,6 @@ where
             _ => T::deserialize_from_value(value, location).map(Setting::Set),
         }
     }
-    fn default() -> Option<Self> {
-        Some(Self::NotSet)
-    }
 }
 
 impl<T> Default for Setting<T> {


### PR DESCRIPTION
Update deserr to 0.1.5, which changes the `DeserializeFromValue` trait, getting rid of the `default()` method.
