### PR TITLE
Fix phrase search containing only stop words

### DIFF
--- a/milli/tests/search/phrase_search.rs
+++ b/milli/tests/search/phrase_search.rs
@@ -40,7 +40,8 @@ fn test_phrase_search_with_stop_words_given_criteria(criteria: &[Criterion]) {
     search.authorize_typos(false);
     search.terms_matching_strategy(TermsMatchingStrategy::All);
     let result = search.execute().unwrap();
-    assert_eq!(result.documents_ids.len(), 0);
+    // act like a placeholder search
+    assert_eq!(result.documents_ids.len(), 10);
 }
 
 #[test]


### PR DESCRIPTION
# Summary

A search with a phrase containing only stop words was returning an HTTP error 500,
this PR filters the phrase containing only stop words dropping them before the search starts, a query with a phrase containing only stop words now behaves like a placeholder search.

fixes https://github.com/meilisearch/meilisearch/issues/3521 for v1.0.2

related v1.1.0 PR on Meilisearch: https://github.com/meilisearch/meilisearch/pull/3525